### PR TITLE
Remove a console.debug for plugin activate

### DIFF
--- a/packages/collaboration-extension/src/filebrowser.ts
+++ b/packages/collaboration-extension/src/filebrowser.ts
@@ -45,9 +45,6 @@ export const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
     labShell: ILabShell | null,
     settingRegistry: ISettingRegistry | null
   ): Promise<IDefaultFileBrowser> => {
-    console.debug(
-      '@jupyter/collaboration-extension:defaultFileBrowser: activated'
-    );
     const { commands } = app;
 
     const trans = translator.load('jupyter_collaboration');


### PR DESCRIPTION
Not sure we need to keep this `console.debug` for shipping the final version of this extension.

Unless it can be considered useful for debugging.

