### PR TITLE
Creates a new FileLoader class to separate the logic of watching files

### DIFF
--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -5,8 +5,8 @@ from jupyter_server.extension.application import ExtensionApp
 from traitlets import Float, Int, Type
 from ypy_websocket.ystore import BaseYStore
 
-from .handlers import DocSessionHandler, SQLiteYStore, YDocWebSocketHandler
-
+from .handlers import DocSessionHandler, YDocWebSocketHandler
+from .stores import SQLiteYStore
 
 class YDocExtension(ExtensionApp):
     name = "jupyter_collaboration"

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -8,6 +8,7 @@ from ypy_websocket.ystore import BaseYStore
 from .handlers import DocSessionHandler, YDocWebSocketHandler
 from .stores import SQLiteYStore
 
+
 class YDocExtension(ExtensionApp):
     name = "jupyter_collaboration"
 

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -13,7 +13,7 @@ class YDocExtension(ExtensionApp):
     name = "jupyter_collaboration"
 
     file_poll_interval = Int(
-        1,
+        5,
         config=True,
         help="""The period in seconds to check for file changes on disk.
         Defaults to 1s, if 0 then file changes will only be checked when
@@ -21,7 +21,7 @@ class YDocExtension(ExtensionApp):
     )
 
     document_cleanup_delay = Int(
-        60,
+        5,
         allow_none=True,
         config=True,
         help="""The delay in seconds to keep a document in memory in the back-end after all clients

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -13,7 +13,7 @@ class YDocExtension(ExtensionApp):
     name = "jupyter_collaboration"
 
     file_poll_interval = Int(
-        5,
+        1,
         config=True,
         help="""The period in seconds to check for file changes on disk.
         Defaults to 1s, if 0 then file changes will only be checked when
@@ -21,7 +21,7 @@ class YDocExtension(ExtensionApp):
     )
 
     document_cleanup_delay = Int(
-        5,
+        60,
         allow_none=True,
         config=True,
         help="""The delay in seconds to keep a document in memory in the back-end after all clients

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -62,3 +62,6 @@ class YDocExtension(ExtensionApp):
                 (r"/api/collaboration/session/(.*)", DocSessionHandler),
             ]
         )
+
+    async def stop_extension(self):
+        YDocWebSocketHandler.clean_up()

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -54,7 +54,7 @@ class JupyterWebsocketServer(WebsocketServer):
             self.ypatch_nb = 0
 
     def room_exists(self, path: str) -> bool:
-        return path in self.rooms.keys()
+        return path in self.rooms
 
     def add_room(self, path: str, room: YRoom) -> None:
         self.rooms[path] = room

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -43,28 +43,61 @@ class JupyterWebsocketServer(WebsocketServer):
         self.ypatch_nb = 0
         self.connected_users = {}
         self.background_tasks = set()
-        self.monitor_task = asyncio.create_task(self.monitor())
+        self.monitor_task = asyncio.create_task(self._monitor())
 
-    async def monitor(self):
+    def room_exists(self, path: str) -> bool:
+        """
+        Returns true is the room exist or false otherwise.
+
+            Parameters:
+                path (str): Room ID.
+
+            Returns:
+                exists (bool): Whether the room exists or not.
+        """
+        return path in self.rooms
+
+    def add_room(self, path: str, room: YRoom) -> None:
+        """
+        Adds a new room.
+
+            Parameters:
+                path (str): Room ID.
+                room (YRoom): A room.
+        """
+        self.rooms[path] = room
+
+    def get_room(self, path: str) -> YRoom:
+        """
+        Returns the room for the specified room ID or raises a RoomNotFound
+        error if the room doesn't exist.
+
+            Parameters:
+                path (str): Room ID.
+
+            Returns:
+                room (YRoom): The room.
+        """
+        if path not in self.rooms:
+            # Document rooms need a file
+            raise RoomNotFound
+
+        return self.rooms[path]
+
+    async def _monitor(self):
+        """
+        An infinite loop with a 60 seconds delay for counting the number
+        of patches processed in a minute and how many clients are connected.
+
+        #### Note:
+            This method runs in a coroutine for debugging purposes.
+        """
         while True:
             await asyncio.sleep(60)
             clients_nb = sum(len(room.clients) for room in self.rooms.values())
             self.log.info("Processed %s Y patches in one minute", self.ypatch_nb)
             self.log.info("Connected Y users: %s", clients_nb)
             self.ypatch_nb = 0
-
-    def room_exists(self, path: str) -> bool:
-        return path in self.rooms
-
-    def add_room(self, path: str, room: YRoom) -> None:
-        self.rooms[path] = room
-
-    def get_room(self, path: str) -> YRoom:
-        if path not in self.rooms:
-            # Document rooms need a file
-            raise RoomNotFound
-
-        return self.rooms[path]
 
 
 class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -5,16 +5,19 @@ import asyncio
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set
+
+from tornado import web
+from tornado.httputil import HTTPServerRequest
+from tornado.websocket import WebSocketHandler
 
 from jupyter_server.auth import authorized
+from jupyter_server.serverapp import ServerWebApplication
 from jupyter_server.base.handlers import APIHandler, JupyterHandler
-from jupyter_server.utils import ensure_async
+
 from jupyter_ydoc import ydocs as YDOCS
-from tornado import web
-from tornado.websocket import WebSocketHandler
+
 from ypy_websocket.websocket_server import WebsocketServer, YRoom
-from ypy_websocket.ystore import YDocNotFound
 from ypy_websocket.yutils import YMessageType
 
 from .rooms import DocumentRoom, TransientRoom, FileLoader
@@ -23,6 +26,9 @@ from .utils import decode_file_path
 YFILE = YDOCS["file"]
 
 SERVER_SESSION = str(uuid.uuid4())
+
+class RoomNotFound(Exception):
+    pass
 
 
 class JupyterWebsocketServer(WebsocketServer):
@@ -48,18 +54,17 @@ class JupyterWebsocketServer(WebsocketServer):
             self.log.info("Connected Y users: %s", clients_nb)
             self.ypatch_nb = 0
 
-    def get_room(self, path: str, file: FileLoader) -> YRoom:
+    def room_exists(self, path: str) -> bool:
+        return path in self.rooms
+
+    def add_room(self, path: str, room: YRoom) -> None:
+        self.rooms[path] = room
+    
+    def get_room(self, path: str) -> YRoom:
         if path not in self.rooms:
-            if path.count(":") >= 2:
-                # it is a stored document (e.g. a notebook)
-                file_format, file_type, file_path = decode_file_path(path)
-                p = Path(file_path)
-                updates_file_path = str(p.parent / f".{file_type}:{p.name}.y")
-                ystore = self.ystore_class(path=updates_file_path, log=self.log)
-                self.rooms[path] = DocumentRoom(path, file, ystore, self.log)
-            else:
-                # it is a transient document (e.g. awareness)
-                self.rooms[path] = TransientRoom(self.log)
+            # Document rooms need a file
+            raise RoomNotFound
+        
         return self.rooms[path]
 
 
@@ -83,10 +88,83 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
        receiving a message.
     """
 
-    saving_document: Optional["asyncio.Task[Any]"]
+    files: Dict[str, FileLoader] = {}
     websocket_server: Optional[JupyterWebsocketServer] = None
     _message_queue: "asyncio.Queue[Any]"
 
+    def __init__(self, app: ServerWebApplication, request: HTTPServerRequest, **kwargs):
+        super().__init__(app, request, **kwargs)
+        print("[__init__] args:", app, request, kwargs)
+
+        # CONFIG
+        self._file_id_manager = self.settings["file_id_manager"]
+        self._ystore_class = self.settings["collaborative_ystore_class"]
+        self._cleanup_delay = self.settings["collaborative_document_cleanup_delay"]
+        #self.settings["collaborative_file_poll_interval"]
+        #self.settings["collaborative_document_save_delay"]
+
+        # Instantiate the JupyterWebsocketServer as a Class property
+        # if it doesn't exist yet
+        if self.websocket_server is None:
+            print("[DocumentWebSocketHandler] First client:")
+            for k, v in self.config.get(self._ystore_class.__name__, {}).items():
+                setattr(self._ystore_class, k, v)
+            
+            YDocWebSocketHandler.websocket_server = JupyterWebsocketServer(
+                rooms_ready=False,
+                auto_clean_rooms=False,
+                ystore_class=self._ystore_class,
+                log=self.log,
+            )
+        
+        # Get room
+        self._room_id: str = request.path.split("/")[-1]
+        print("ROOM ID:", self._room_id)
+
+        if self.websocket_server.room_exists(self._room_id):
+            self.room: YRoom = self.websocket_server.get_room(self._room_id)
+        
+        else :
+            if self._room_id.count(":") >= 2:
+                # DocumentRoom
+                _, file_type, file_id = decode_file_path(self._room_id)
+                self._path = self._file_id_manager.get_path(file_id)
+                print("File path:", self._path)
+                
+                # Instantiate the FileLoader if it doesn't exist yet
+                file = YDocWebSocketHandler.files.get(self._path)
+                if file is None:
+                    file = FileLoader(
+                        self._path,
+                        self.contents_manager,
+                        self.settings["collaborative_document_save_delay"],
+                        self.settings["collaborative_file_poll_interval"]
+                    )
+                    self.files[self._path] = file
+                
+                path = Path(self._path)
+                updates_file_path = str(path.parent / f".{file_type}:{path.name}.y")
+                ystore = self._ystore_class(path=updates_file_path, log=self.log)
+                self.room = DocumentRoom(self._room_id, file, ystore, self.log)
+            
+            else :
+                # TransientRoom
+                # it is a transient document (e.g. awareness)
+                self.room = TransientRoom(self.log)
+            
+            self.websocket_server.add_room(self._room_id, self.room)
+            print("room:", self._room_id, self.room.ready)
+        
+        self._message_queue = asyncio.Queue()
+
+        task = asyncio.create_task(self.websocket_server.serve(self))
+        self.websocket_server.background_tasks.add(task)
+        task.add_done_callback(self.websocket_server.background_tasks.discard)
+
+    @property
+    def path(self):
+        return self._room_id
+    
     # Override max_message size to 1GB
     @property
     def max_message_size(self):
@@ -103,34 +181,6 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             raise StopAsyncIteration()
         return message
 
-    def get_file_info(self) -> Tuple[str, str, str]:
-        assert self.websocket_server is not None
-        assert isinstance(self.room, DocumentRoom)
-        room_name = self.websocket_server.get_room_name(self.room)
-        file_format: str
-        file_type: str
-        file_path: Optional[str]
-        file_id: str
-        file_format, file_type, file_id = room_name.split(":", 2)
-        file_path = self.settings["file_id_manager"].get_path(file_id)
-        if file_path is None:
-            raise RuntimeError(f"File {self.room.document.path} cannot be found anymore")
-        assert file_path is not None
-        if file_path != self.room.document.path:
-            self.log.debug(
-                "File with ID %s was moved from %s to %s",
-                file_id,
-                self.room.document.path,
-                file_path,
-            )
-            self.room.document.path = file_path
-        return file_format, file_type, file_path
-
-    def set_file_info(self, value: str) -> None:
-        assert self.websocket_server is not None
-        self.websocket_server.rename_room(value, from_room=self.room)
-        self.path = value  # needed to be compatible with WebsocketServer (websocket.path)
-
     async def get(self, *args, **kwargs):
         if self.get_current_user() is None:
             self.log.warning("Couldn't authenticate WebSocket connection")
@@ -138,26 +188,8 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         return await super().get(*args, **kwargs)
 
     async def open(self, path):
-        ystore_class = self.settings["collaborative_ystore_class"]
-        if self.websocket_server is None:
-            for k, v in self.config.get(ystore_class.__name__, {}).items():
-                setattr(ystore_class, k, v)
-            YDocWebSocketHandler.websocket_server = JupyterWebsocketServer(
-                rooms_ready=False,
-                auto_clean_rooms=False,
-                ystore_class=ystore_class,
-                log=self.log,
-            )
-        self._message_queue = asyncio.Queue()
-        self.lock = asyncio.Lock()
-        assert self.websocket_server is not None
-        self.room = self.websocket_server.get_room(path)
-        self.set_file_info(path)
-        self.saving_document = None
-        task = asyncio.create_task(self.websocket_server.serve(self))
-        self.websocket_server.background_tasks.add(task)
-        task.add_done_callback(self.websocket_server.background_tasks.discard)
-
+        #self.set_file_info(path)
+        
         # Close the connection if the document session expired
         session_id = self.get_query_argument("sessionId", "")
         if isinstance(self.room, DocumentRoom) and SERVER_SESSION != session_id:
@@ -168,65 +200,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             self.room.cleaner.cancel()
 
         if isinstance(self.room, DocumentRoom) and not self.room.ready:
-            file_format, file_type, file_path = self.get_file_info()
-            self.log.debug("Opening Y document from disk: %s", file_path)
-            model = await ensure_async(
-                self.contents_manager.get(file_path, type=file_type, format=file_format)
-            )
-            self.last_modified = model["last_modified"]
-            # check again if ready, because loading the file can be async
-            if not self.room.ready:
-                # try to apply Y updates from the YStore for this document
-                read_from_source = True
-                if self.room.ystore is not None:
-                    try:
-                        await self.room.ystore.apply_updates(self.room.ydoc)
-                        read_from_source = False
-                    except YDocNotFound:
-                        # YDoc not found in the YStore, create the document from the source file (no change history)
-                        pass
-                if not read_from_source:
-                    # if YStore updates and source file are out-of-sync, resync updates with source
-                    if self.room.document.source != model["content"]:
-                        read_from_source = True
-
-                if read_from_source:
-                    self.room.document.source = model["content"]
-                    if self.room.ystore:
-                        await self.room.ystore.encode_state_as_update(self.room.ydoc)
-                self.room.document.dirty = False
-                self.room.ready = True
-                self.room.watcher = asyncio.create_task(self.watch_file())
-                # save the document when changed
-                self.room.document.observe(self.on_document_change)
-
-    async def watch_file(self):
-        assert isinstance(self.room, DocumentRoom)
-        poll_interval = self.settings["collaborative_file_poll_interval"]
-        if not poll_interval:
-            self.room.watcher = None
-            return
-        while True:
-            await asyncio.sleep(poll_interval)
-            await self.maybe_load_document()
-
-    async def maybe_load_document(self):
-        assert isinstance(self.room, DocumentRoom)
-        file_format, file_type, file_path = self.get_file_info()
-        async with self.lock:
-            model = await ensure_async(
-                self.contents_manager.get(
-                    file_path, content=False, type=file_type, format=file_format
-                )
-            )
-        # do nothing if the file was saved by us
-        if self.last_modified < model["last_modified"]:
-            self.log.debug("Reverting file that had out-of-band changes: %s", file_path)
-            model = await ensure_async(
-                self.contents_manager.get(file_path, type=file_type, format=file_format)
-            )
-            self.room.document.source = model["content"]
-            self.last_modified = model["last_modified"]
+            await self.room.initialize()
 
     async def send(self, message):
         # needed to be compatible with WebsocketServer (websocket.send)
@@ -279,64 +253,24 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
 
     async def clean_room(self) -> None:
         assert isinstance(self.room, DocumentRoom)
-        seconds = self.settings["collaborative_document_cleanup_delay"]
-        if seconds is None:
+        
+        if self._cleanup_delay is None:
             return
-        await asyncio.sleep(seconds)
-        if self.room.watcher is not None:
-            self.room.watcher.cancel()
-        self.room.document.unobserve()
+        
+        await asyncio.sleep(self._cleanup_delay)
+        
+        # Clean room
+        del self.room
+
+        # Clean the file loader
+        file = self.files[self._path]
+        if file.number_of_rooms() == 0 :
+            del self.files[self._path]
+
+        # Remove the room from the websocket server
         assert self.websocket_server is not None
-        file_format, file_type, file_path = self.get_file_info()
-        self.log.debug("Deleting Y document from memory: %s", file_path)
+        self.log.debug("Deleting Y document from memory: %s", self.room.room_id)
         self.websocket_server.delete_room(room=self.room)
-
-    def on_document_change(self, target, event):
-        if target == "state" and "dirty" in event.keys:
-            dirty = event.keys["dirty"]["newValue"]
-            if not dirty:
-                # we cleared the dirty flag, nothing to save
-                return
-        if self.saving_document is not None and not self.saving_document.done():
-            # the document is being saved, cancel that
-            self.saving_document.cancel()
-            self.saving_document = None
-        self.saving_document = asyncio.create_task(self.maybe_save_document())
-
-    async def maybe_save_document(self):
-        assert isinstance(self.room, DocumentRoom)
-        seconds = self.settings["collaborative_document_save_delay"]
-        if seconds is None:
-            return
-        # save after X seconds of inactivity
-        await asyncio.sleep(seconds)
-        # if the room cannot be found, don't save
-        try:
-            file_format, file_type, file_path = self.get_file_info()
-        except Exception:
-            return
-        self.log.debug("Opening Y document from disk: %s", file_path)
-        async with self.lock:
-            model = await ensure_async(
-                self.contents_manager.get(file_path, type=file_type, format=file_format)
-            )
-        if self.last_modified < model["last_modified"]:
-            # file changed on disk, let's revert
-            self.log.debug("Reverting file that had out-of-band changes: %s", file_path)
-            self.room.document.source = model["content"]
-            self.last_modified = model["last_modified"]
-            return
-        if model["content"] != self.room.document.source:
-            # don't save if not needed
-            # this also prevents the dirty flag from bouncing between windows of
-            # the same document opened as different types (e.g. notebook/text editor)
-            model["format"] = file_format
-            model["content"] = self.room.document.source
-            self.log.debug("Saving Y document to disk: %s", file_path)
-            async with self.lock:
-                model = await ensure_async(self.contents_manager.save(model, file_path))
-                self.last_modified = model["last_modified"]
-        self.room.document.dirty = False
 
     def check_origin(self, origin):
         return True

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import uuid
+from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
@@ -369,16 +370,20 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
 
         Useful to clean up tasks on server shut down.
         """
-        assert cls.websocket_server is not None
-        # Cancel tasks and clean up
-        # TODO: should we wait for any save task?
-        rooms = list(cls.websocket_server.rooms.values())
-        for room in rooms:
-            cls.websocket_server.delete_room(room=room)
+        log = getLogger(__name__)
+        log.info("Cleaning up resources before server shut down.")
+        if cls.websocket_server is not None:
+            # Cancel tasks and clean up
+            # TODO: should we wait for any save task?
+            rooms = list(cls.websocket_server.rooms.values())
+            log.info("Deleting rooms.")
+            for room in rooms:
+                cls.websocket_server.delete_room(room=room)
 
         for file in cls.files.values():
             file.clean()
 
+        log.info("Deleting files.")
         cls.files.clear()
 
 

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -284,7 +284,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         # Clean the file loader if there are not rooms using it
         _, _, file_id = decode_file_path(self._room_id)
         file = self.files[file_id]
-        if file.number_of_subscriptions() == 0:
+        if file.number_of_subscriptions == 0:
             self.log.info("Deleting file %s", file.path)
             file.clean()
             del self.files[file_id]

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -286,10 +286,24 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         file = self.files[self._path]
         if file.number_of_subscriptions() == 0:
             self.log.info("Deleting file %s", file.path)
+            file.clean()
             del self.files[self._path]
 
     def check_origin(self, origin):
         return True
+
+    @classmethod
+    def clean_up(cls):
+        # Cancel tasks and clean up
+        # TODO: should we wait for any save task?
+        rooms = list(cls.websocket_server.rooms.values())
+        for room in rooms:
+            cls.websocket_server.delete_room(room=room)
+
+        for file in cls.files.values():
+            file.clean()
+
+        cls.files.clear()
 
 
 class DocSessionHandler(APIHandler):

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -7,7 +7,6 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
-from jupyter_events import EventLogger
 from jupyter_server.auth import authorized
 from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from jupyter_server.serverapp import ServerWebApplication

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from logging import Logger, getLogger
 from typing import Any, Callable, Coroutine, Dict, Optional
@@ -12,8 +14,8 @@ class FileLoader:
         file_format: str,
         file_type: str,
         contents_manager: Any,
-        log: Optional[Logger],
-        poll_interval: Optional[float] = None,
+        log: Logger | None,
+        poll_interval: float | None = None,
     ) -> None:
         self._path: str = path
         self._file_format: str = file_format
@@ -25,7 +27,7 @@ class FileLoader:
         self._contents_manager = contents_manager
 
         self._log = log or getLogger(__name__)
-        self._subscriptions: Dict[str, Callable[[str], Coroutine[Any, Any, None]]] = {}
+        self._subscriptions: dict[str, Callable[[str], Coroutine[Any, Any, None]]] = {}
 
         if self._poll_interval:
             self._watcher = asyncio.create_task(self.watch_file())
@@ -49,12 +51,12 @@ class FileLoader:
     def unobserve(self, id: str) -> None:
         del self._subscriptions[id]
 
-    async def load_content(self, format: str, file_type: str, content: bool) -> Dict[str, Any]:
+    async def load_content(self, format: str, file_type: str, content: bool) -> dict[str, Any]:
         return await ensure_async(
             self._contents_manager.get(self._path, format=format, type=file_type, content=content)
         )
 
-    async def save_content(self, model: Dict[str, Any]) -> None:
+    async def save_content(self, model: dict[str, Any]) -> None:
         async with self._lock:
             m = await self.load_content(model["format"], model["type"], False)
 

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -111,6 +111,12 @@ class FileLoader:
 
             Parameters:
                 model (dict): A dictionary with format, type, last_modified, and content of the file.
+
+            Returns:
+                model (dict): A dictionary with the metadata and content of the file.
+
+        ### Note:
+            If there is changes on disk, this method will raise an OutOfBandChanges exception.
         """
         async with self._lock:
             path = self.path
@@ -139,7 +145,11 @@ class FileLoader:
 
         while True:
             await asyncio.sleep(self._poll_interval)
-            await self._maybe_load_document()
+            try:
+                await self._maybe_load_document()
+
+            except Exception as e:
+                self._log.error("Error watching file: %s\n", self.path, e)
 
     async def _maybe_load_document(self) -> None:
         """

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -61,7 +61,11 @@ class FileLoader:
 
     async def save_content(self, model: dict[str, Any]) -> None:
         async with self._lock:
-            m = await self.load_content(model["format"], model["type"], False)
+            m = await ensure_async(
+                self._contents_manager.get(
+                    self._path, format=model["format"], type=model["type"], content=False
+                )
+            )
 
             if self._last_modified is None or self._last_modified == m["last_modified"]:
                 self._log.info("Saving file: %s", self._path)
@@ -88,7 +92,11 @@ class FileLoader:
 
     async def _maybe_load_document(self) -> None:
         async with self._lock:
-            model = await self.load_content(self._file_format, self._file_type, False)
+            model = await ensure_async(
+                self._contents_manager.get(
+                    self._path, format=self._file_format, type=self._file_type, content=False
+                )
+            )
 
             # do nothing if the file was saved by us
             if self._last_modified is not None and self._last_modified < model["last_modified"]:

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -75,6 +75,7 @@ class FileLoader:
 
     async def watch_file(self) -> None:
         self._log.info("Watching file: %s", self._path)
+        assert self._poll_interval is not None
 
         while True:
             await asyncio.sleep(self._poll_interval)

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -4,26 +4,29 @@ import asyncio
 from logging import Logger, getLogger
 from typing import Any, Callable, Coroutine, Dict, Optional
 
+from jupyter_events import EventLogger
 from jupyter_server.utils import ensure_async
 
 
 class FileLoader:
     def __init__(
         self,
-        path: str,
+        file_id: str,
         file_format: str,
         file_type: str,
+        file_id_manager: Any,
         contents_manager: Any,
         log: Logger | None,
         poll_interval: float | None = None,
     ) -> None:
-        self._path: str = path
+        self._file_id: str = file_id
         self._file_format: str = file_format
         self._file_type: str = file_type
         self._last_modified = None
 
         self._lock = asyncio.Lock()
         self._poll_interval = poll_interval
+        self._file_id_manager = file_id_manager
         self._contents_manager = contents_manager
 
         self._log = log or getLogger(__name__)
@@ -34,13 +37,10 @@ class FileLoader:
 
     @property
     def path(self):
-        return self._path
+        return self._file_id_manager.get_path(self._file_id)
 
     def clean(self) -> None:
         self._watcher.cancel()
-
-    def rename_file(self, path: str) -> None:
-        self._path = path
 
     def number_of_subscriptions(self) -> int:
         return len(self._subscriptions)
@@ -55,27 +55,28 @@ class FileLoader:
         async with self._lock:
             return await ensure_async(
                 self._contents_manager.get(
-                    self._path, format=format, type=file_type, content=content
+                    self.path, format=format, type=file_type, content=content
                 )
             )
 
     async def save_content(self, model: dict[str, Any]) -> None:
         async with self._lock:
+            path = self.path
             m = await ensure_async(
                 self._contents_manager.get(
-                    self._path, format=model["format"], type=model["type"], content=False
+                    path, format=model["format"], type=model["type"], content=False
                 )
             )
 
             if self._last_modified is None or self._last_modified == m["last_modified"]:
-                self._log.info("Saving file: %s", self._path)
-                model = await ensure_async(self._contents_manager.save(model, self._path))
+                self._log.info("Saving file: %s", path)
+                model = await ensure_async(self._contents_manager.save(model, path))
                 self._last_modified = model["last_modified"]
 
             else:
                 # file changed on disk, let's revert
                 self._log.info(
-                    "Notifying rooms. Out-of-band changes while trying to save: %s", self._path
+                    "Notifying rooms. Out-of-band changes while trying to save: %s", path
                 )
                 self._last_modified = model["last_modified"]
                 # Notify that the content changed on disk
@@ -83,7 +84,7 @@ class FileLoader:
                     await callback("changed")
 
     async def watch_file(self) -> None:
-        self._log.info("Watching file: %s", self._path)
+        self._log.info("Watching file: %s", self.path)
         assert self._poll_interval is not None
 
         while True:
@@ -92,15 +93,16 @@ class FileLoader:
 
     async def _maybe_load_document(self) -> None:
         async with self._lock:
+            path = self.path
             model = await ensure_async(
                 self._contents_manager.get(
-                    self._path, format=self._file_format, type=self._file_type, content=False
+                    path, format=self._file_format, type=self._file_type, content=False
                 )
             )
 
             # do nothing if the file was saved by us
             if self._last_modified is not None and self._last_modified < model["last_modified"]:
-                self._log.info("Notifying rooms. The file on disk changed: %s", self._path)
+                self._log.info("Notifying rooms. The file on disk changed: %s", path)
                 self._last_modified = model["last_modified"]
                 # Notify that the content changed on disk
                 for callback in self._subscriptions.values():

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from logging import Logger, getLogger
-from typing import Any, Callable, Coroutine, Dict, Optional
+from typing import Any, Callable, Coroutine
 
-from jupyter_events import EventLogger
 from jupyter_server.utils import ensure_async
 
 

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -34,7 +34,7 @@ class FileLoader:
     def path(self):
         return self._path
 
-    def __del__(self) -> None:
+    def clean(self) -> None:
         self._watcher.cancel()
 
     def rename_file(self, path: str) -> None:

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -36,13 +36,14 @@ class FileLoader:
     @property
     def path(self) -> str:
         return self._file_id_manager.get_path(self._file_id)
-    
+
     @property
     def number_of_subscriptions(self) -> int:
         return len(self._subscriptions)
 
     def clean(self) -> None:
-        self._watcher.cancel()
+        if self._watcher is not None:
+            self._watcher.cancel()
 
     def observe(self, id: str, callback: Callable[[str], Coroutine[Any, Any, None]]) -> None:
         self._subscriptions[id] = callback
@@ -84,6 +85,9 @@ class FileLoader:
 
     async def _watch_file(self) -> None:
         self._log.info("Watching file: %s", self.path)
+
+        if self._poll_interval is None:
+            return
 
         while True:
             await asyncio.sleep(self._poll_interval)

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -3,7 +3,8 @@ from typing import Any, Dict
 
 from jupyter_server.utils import ensure_async
 
-from .rooms import DocumentRoom
+from ypy_websocket.websocket_server import YRoom
+
 from .utils import decode_file_path
 
 
@@ -14,7 +15,7 @@ class FileLoader():
         self._path = path
         self._last_modified = None
         self._lock = asyncio.Lock()
-        self._rooms: Dict[str, DocumentRoom] = {}
+        self._rooms: Dict[str, YRoom] = {}
 
         self._save_delay = save_delay
         self._poll_interval = poll_interval
@@ -29,7 +30,7 @@ class FileLoader():
     def number_of_rooms(self) -> int:
         return len(self._rooms)
     
-    def add_room(self, room_id: str, room: DocumentRoom) -> None:
+    def add_room(self, room_id: str, room: YRoom) -> None:
         self._rooms[room_id] = room
     
     def remove_room(self, room_id: str) -> None:

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -1,0 +1,112 @@
+import asyncio
+from typing import Any, Dict
+
+from jupyter_server.utils import ensure_async
+
+from .rooms import DocumentRoom
+from .utils import decode_file_path
+
+
+class FileLoader():
+
+    def __init__(self, path: str, contents_manager: Any, save_delay: str = None, poll_interval: str = None) -> None:
+        
+        self._path = path
+        self._last_modified = None
+        self._lock = asyncio.Lock()
+        self._rooms: Dict[str, DocumentRoom] = {}
+
+        self._save_delay = save_delay
+        self._poll_interval = poll_interval
+        self._contents_manager = contents_manager
+        
+        self._saving_document = None
+        self._watcher = asyncio.create_task(self.watch_file())
+    
+    def rename_file(self, path: str):
+        self._path = path
+
+    def number_of_rooms(self) -> int:
+        return len(self._rooms)
+    
+    def add_room(self, room_id: str, room: DocumentRoom) -> None:
+        self._rooms[room_id] = room
+    
+    def remove_room(self, room_id: str) -> None:
+        del self._rooms[room_id]
+    
+    async def load_file_data(self, format: str, file_type: str, content: bool) -> Dict[str, Any]:
+        return await ensure_async(
+            self.contents_manager.get(self._path, format=format, type=file_type, content=content)
+        )
+    
+    async def save_content(self, model: Dict[str, Any]):
+        if self._saving_document is not None and not self._saving_document.done():
+            # the document is being saved, cancel that
+            self._saving_document.cancel()
+            self._saving_document = None
+
+        self._saving_document = asyncio.create_task(
+            self._maybe_save_document(model)
+        )
+        
+    async def watch_file(self):
+        if not self._poll_interval:
+            self._watcher = None
+            return
+        
+        while True:
+            await asyncio.sleep(self._poll_interval)
+            await self._maybe_load_document()
+
+    async def _maybe_load_document(self):
+        # Check whether there is rooms, and get the metadata from
+        # the first room.
+        # Doesn't mather which 'type' and 'format' we use since we
+        # are not loading the content
+        if not len(self._rooms):
+            return
+
+        # Get format and type from room_id
+        format, file_type, _ = decode_file_path(self._rooms.keys()[0])
+
+        async with self._lock:
+            model = self.load_file_data(format, file_type, False)
+        
+        # do nothing if the file was saved by us
+        if self._last_modified < model["last_modified"]:
+            self.log.debug("Reverting file that had out-of-band changes: %s", self._path)
+            self._last_modified = model["last_modified"]
+            # Load the content for each room accessing this file
+            for room_id, room in self._rooms.items():
+                room.set_document_content()
+                
+    
+    async def _maybe_save_document(self, model: Dict[str, Any]):
+        if self._save_delay is None:
+            return
+        
+        # save after X seconds of inactivity
+        await asyncio.sleep(self._save_delay)
+        
+        self.log.debug("Opening Y document from disk: %s", self._path)
+        async with self._lock:
+            model = await self.load_file_data(model["format"], model["type"], False)
+        
+        if self._last_modified < model["last_modified"]:
+            # file changed on disk, let's revert
+            self.log.debug("Reverting file that had out-of-band changes: %s", self._path)
+            self._last_modified = model["last_modified"]
+            # Load the content for each room accessing this file
+            for room_id, room in self._rooms.items():
+                room.set_document_content()
+            
+            return
+
+        async with self._lock:
+            model = await ensure_async(self.contents_manager.save(model, self._path))
+            self._last_modified = model["last_modified"]
+            # Set dirty to false for each room accessing this file
+            for room_id, room in self._rooms.items():
+                room.clear_dirty_flag()
+            

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -1,79 +1,93 @@
 import asyncio
-from typing import Any, Dict, Callable
+from logging import Logger, getLogger
+from typing import Any, Callable, Coroutine, Dict, Optional
 
 from jupyter_server.utils import ensure_async
 
 
-class FileLoader():
-
-    def __init__(self, path: str, file_format: str, file_type: str, contents_manager: Any, poll_interval: int = None) -> None:
+class FileLoader:
+    def __init__(
+        self,
+        path: str,
+        file_format: str,
+        file_type: str,
+        contents_manager: Any,
+        log: Optional[Logger],
+        poll_interval: Optional[float] = None,
+    ) -> None:
         self._path: str = path
         self._file_format: str = file_format
         self._file_type: str = file_type
         self._last_modified = None
-        
+
         self._lock = asyncio.Lock()
         self._poll_interval = poll_interval
         self._contents_manager = contents_manager
 
-        self._subscriptions: Dict[str, Callable] = {}
-        self._watcher = asyncio.create_task(self.watch_file())
-    
+        self._log = log or getLogger(__name__)
+        self._subscriptions: Dict[str, Callable[[str], Coroutine[Any, Any, None]]] = {}
+
+        if self._poll_interval:
+            self._watcher = asyncio.create_task(self.watch_file())
+
+    @property
+    def path(self):
+        return self._path
+
     def __del__(self) -> None:
         self._watcher.cancel()
 
-    def rename_file(self, path: str):
+    def rename_file(self, path: str) -> None:
         self._path = path
 
     def number_of_subscriptions(self) -> int:
         return len(self._subscriptions)
-    
-    def observe(self, id: str, callback: Callable) -> None:
+
+    def observe(self, id: str, callback: Callable[[str], Coroutine[Any, Any, None]]) -> None:
         self._subscriptions[id] = callback
-    
+
     def unobserve(self, id: str) -> None:
         del self._subscriptions[id]
-    
+
     async def load_content(self, format: str, file_type: str, content: bool) -> Dict[str, Any]:
         return await ensure_async(
             self._contents_manager.get(self._path, format=format, type=file_type, content=content)
         )
-    
-    async def save_content(self, model: Dict[str, Any]):
-        #self.log.debug("Opening Y document from disk: %s", self._path)
+
+    async def save_content(self, model: Dict[str, Any]) -> None:
         async with self._lock:
             m = await self.load_content(model["format"], model["type"], False)
-        
+
             if self._last_modified is None or self._last_modified >= m["last_modified"]:
+                self._log.info("Saving file: %s", self._path)
                 model = await ensure_async(self._contents_manager.save(model, self._path))
                 self._last_modified = model["last_modified"]
-                
-            else :
+
+            else:
                 # file changed on disk, let's revert
-                #self.log.debug("Reverting file that had out-of-band changes: %s", self._path)
+                self._log.info(
+                    "Notifying rooms. Out-of-band changes while trying to save: %s", self._path
+                )
                 self._last_modified = model["last_modified"]
                 # Notify that the content changed on disk
                 for _, callback in self._subscriptions.items():
-                    callback('changed')
-            
-        
-    async def watch_file(self):
-        if not self._poll_interval:
-            self._watcher = None
-            return
-        
+                    await callback("changed")
+
+    async def watch_file(self) -> None:
+        self._log.info("Watching file: %s", self._path)
+
         while True:
             await asyncio.sleep(self._poll_interval)
             await self._maybe_load_document()
 
-    async def _maybe_load_document(self):
-        if not self._lock.locked():
-            model = self.load_content(self._file_format, self._file_type, False)
-            
+    async def _maybe_load_document(self) -> None:
+        async with self._lock:
+            model = await self.load_content(self._file_format, self._file_type, False)
+
             # do nothing if the file was saved by us
-            if self._last_modified < model["last_modified"]:
-                #self.log.debug("Reverting file that had out-of-band changes: %s", self._path)
+            if self._last_modified is not None and self._last_modified < model["last_modified"]:
+                self._log.info("Notifying rooms. The file on disk changed: %s", self._path)
                 self._last_modified = model["last_modified"]
                 # Notify that the content changed on disk
                 for _, callback in self._subscriptions.items():
-                    callback('changed')
+                    await callback("changed")

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -1,8 +1,9 @@
+import asyncio
 from logging import Logger
 from typing import Optional
 
 from ypy_websocket.websocket_server import YRoom
-from ypy_websocket.ystore import BaseYStore
+from ypy_websocket.ystore import BaseYStore, YDocNotFound
 
 from jupyter_ydoc import ydocs as YDOCS
 
@@ -16,35 +17,72 @@ class DocumentRoom(YRoom):
 
     def __init__(self, room_id: str, file: FileLoader, ystore: Optional[BaseYStore], log: Optional[Logger]):
         super().__init__(ready=False, ystore=ystore, log=log)
+        
         self._room_id: str = room_id
         self._file: FileLoader = file
         self._document = YDOCS.get(type, YFILE)(self.ydoc)
 
         # Add room to the file for loading content
-        self._file.add_room(self._room_id, self)
+        self._file.add_room(self.room_id, self)
+
+        self._cleaner: asyncio.Task = None
 
         # save the document when changed
         self._document.observe(self._on_document_change)
 
+    @property
+    def room_id(self) -> str:
+        return self._room_id
+    
+    @property
+    def cleaner(self) -> asyncio.Task:
+        return self._cleaner
+    
+    @cleaner.setter
+    def cleaner(self, value: asyncio.Task) -> None:
+        self._cleaner = value
+    
+    def __del__(self) -> None:
+        self._document.unobserve()
+        self._file.remove_room(self.room_id)
+    
     async def initialize(self):
+        format, file_type, _ = decode_file_path(self._room_id)
+        model = await self._file.load_file_data(format, file_type, True)
+        print(model)
+
+        # try to apply Y updates from the YStore for this document
+        read_from_source = True
+        if self.ystore is not None:
+            try:
+                await self.ystore.apply_updates(self.ydoc)
+                read_from_source = False
+            except YDocNotFound:
+                # YDoc not found in the YStore, create the document from the source file (no change history)
+                pass
+        
+        if not read_from_source:
+            # if YStore updates and source file are out-of-sync, resync updates with source
+            if self._document.source != model["content"]:
+                read_from_source = True
+
+        if read_from_source:
+            self._document.source = model["content"]
+            if self.ystore:
+                await self.ystore.encode_state_as_update(self.ydoc)
+        
         await self.set_document_content()
         self._ready = True
-    
-    def clean_room(self) -> None:
-        self._document.unobserve()
-        self._file.remove_room(self._room_id)
 
     def clear_dirty_flag(self) -> None:
-        self.room.document.dirty = False
+        self._document.dirty = False
 
     async def set_document_content(self) -> None:
         format, file_type, _ = decode_file_path(self._room_id)
         model = await self._file.load_file_data(format, file_type, True)
-        self.room.document.source = model["content"]
+        self._document.source = model["content"]
         self.clear_dirty_flag()
     
-
-
     def _on_document_change(self, target, event):
         if target == "state" and "dirty" in event.keys:
             dirty = event.keys["dirty"]["newValue"]

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -13,6 +13,25 @@ from .loaders import FileLoader, OutOfBandChanges
 YFILE = YDOCS["file"]
 
 
+class UpdateFlag:
+    """
+    A context manager for ignoring self updates in the document.
+    """
+
+    def __init__(self):
+        self._updating = False
+
+    def __enter__(self):
+        self._updating = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._updating = False
+
+    @property
+    def updating(self) -> bool:
+        return self._updating
+
+
 class DocumentRoom(YRoom):
     """A Y room for a possibly stored document (e.g. a notebook)."""
 
@@ -38,6 +57,7 @@ class DocumentRoom(YRoom):
         self._save_delay = save_delay
 
         self._lock = asyncio.Lock()
+        self._flag = UpdateFlag()
         self._cleaner: asyncio.Task | None = None
         self._saving_document: asyncio.Task | None = None
 
@@ -88,45 +108,44 @@ class DocumentRoom(YRoom):
             self.log.info("Initializing room %s", self._room_id)
             model = await self._file.load_content(self._file_format, self._file_type, True)
 
-            # try to apply Y updates from the YStore for this document
-            read_from_source = True
-            if self.ystore is not None:
-                try:
-                    await self.ystore.apply_updates(self.ydoc)
+            with self._flag:
+                # try to apply Y updates from the YStore for this document
+                read_from_source = True
+                if self.ystore is not None:
+                    try:
+                        await self.ystore.apply_updates(self.ydoc)
+                        self.log.info(
+                            "Content in room %s loaded from the ystore %s",
+                            self._room_id,
+                            self.ystore.__class__.__name__,
+                        )
+                        read_from_source = False
+                    except YDocNotFound:
+                        # YDoc not found in the YStore, create the document from the source file (no change history)
+                        pass
+
+                if not read_from_source:
+                    # if YStore updates and source file are out-of-sync, resync updates with source
+                    if self._document.source != model["content"]:
+                        self.log.info(
+                            "Content in file %s is out-of-sync with the ystore %s",
+                            self._file.path,
+                            self.ystore.__class__.__name__,
+                        )
+                        read_from_source = True
+
+                if read_from_source:
                     self.log.info(
-                        "Content in room %s loaded from the ystore %s",
-                        self._room_id,
-                        self.ystore.__class__.__name__,
+                        "Content in room %s loaded from file %s", self._room_id, self._file.path
                     )
-                    read_from_source = False
-                except YDocNotFound:
-                    # YDoc not found in the YStore, create the document from the source file (no change history)
-                    pass
+                    self._document.source = model["content"]
 
-            if not read_from_source:
-                # if YStore updates and source file are out-of-sync, resync updates with source
-                if self._document.source != model["content"]:
-                    self.log.info(
-                        "Content in file %s is out-of-sync with the ystore %s",
-                        self._file.path,
-                        self.ystore.__class__.__name__,
-                    )
-                    read_from_source = True
+                    if self.ystore:
+                        await self.ystore.encode_state_as_update(self.ydoc)
 
-            if read_from_source:
-                self.log.info(
-                    "Content in room %s loaded from file %s", self._room_id, self._file.path
-                )
-                self._document.source = model["content"]
-
-                if self.ystore:
-                    await self.ystore.encode_state_as_update(self.ydoc)
-
-            print("INITIALIZE: last_modified", model["last_modified"])
-            print("INITIALIZE: ", model)
-            self._last_modified = model["last_modified"]
-            self._document.dirty = False
-            self.ready = True
+                self._last_modified = model["last_modified"]
+                self._document.dirty = False
+                self.ready = True
 
     def _clean(self) -> None:
         """
@@ -138,6 +157,7 @@ class DocumentRoom(YRoom):
         # TODO: Should we cancel or wait ?
         if self._saving_document:
             self._saving_document.cancel()
+
         self._document.unobserve()
         self._file.unobserve(self.room_id)
 
@@ -147,22 +167,17 @@ class DocumentRoom(YRoom):
 
             Parameters:
                 event (str): Type of change.
+                args (dict): A dictionary with format, type, last_modified.
         """
         if event == "metadata" and self._last_modified < args["last_modified"]:
             model = await self._file.load_content(self._file_format, self._file_type, True)
 
-            if self._document.source != model["content"]:
-                self.log.info(
-                    "Out-of-band changes. Overwriting the content in room %s", self._room_id
-                )
+            self.log.info("Out-of-band changes. Overwriting the content in room %s", self._room_id)
+
+            with self._flag:
                 self._document.source = model["content"]
                 self._last_modified = model["last_modified"]
                 self._document.dirty = False
-
-            else:
-                # Update last_modify because this attribute changed on disk
-                # even though the content did not.
-                self._last_modified = model["last_modified"]
 
     def _on_document_change(self, target: str, event: Any) -> None:
         """
@@ -179,11 +194,8 @@ class DocumentRoom(YRoom):
             document. This tasks are debounced (60 seconds by default) so we
             need to cancel previous tasks before creating a new one.
         """
-        if target == "state" and "dirty" in event.keys:
-            dirty = event.keys["dirty"]["newValue"]
-            if not dirty:
-                # we cleared the dirty flag, nothing to save
-                return
+        if self._flag.updating == True:
+            return
 
         if self._saving_document is not None and not self._saving_document.done():
             # the document is being saved, cancel that
@@ -218,14 +230,16 @@ class DocumentRoom(YRoom):
                 }
             )
             self._last_modified = model["last_modified"]
-            self._document.dirty = False
+            with self._flag:
+                self._document.dirty = False
 
         except OutOfBandChanges:
             self.log.info("Out-of-band changes. Overwriting the content in room %s", self._room_id)
             model = await self._file.load_content(self._file_format, self._file_type, True)
-            self._document.source = model["content"]
-            self._last_modified = model["last_modified"]
-            self._document.dirty = False
+            with self._flag:
+                self._document.source = model["content"]
+                self._last_modified = model["last_modified"]
+                self._document.dirty = False
 
 
 class TransientRoom(YRoom):

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from logging import Logger
 from typing import Any, Optional
@@ -20,9 +22,9 @@ class DocumentRoom(YRoom):
         file_format: str,
         file_type: str,
         file: FileLoader,
-        ystore: Optional[BaseYStore],
-        log: Optional[Logger],
-        save_delay: Optional[int] = None,
+        ystore: BaseYStore | None,
+        log: Logger | None,
+        save_delay: int | None = None,
     ):
         super().__init__(ready=False, ystore=ystore, log=log)
 
@@ -35,8 +37,8 @@ class DocumentRoom(YRoom):
         self._save_delay = save_delay
 
         self._lock = asyncio.Lock()
-        self._cleaner: Optional[asyncio.Task] = None
-        self._saving_document: Optional[asyncio.Task] = None
+        self._cleaner: asyncio.Task | None = None
+        self._saving_document: asyncio.Task | None = None
 
         # Listen for document changes
         self._document.observe(self._on_document_change)
@@ -47,7 +49,7 @@ class DocumentRoom(YRoom):
         return self._room_id
 
     @property
-    def cleaner(self) -> Optional[asyncio.Task]:
+    def cleaner(self) -> asyncio.Task | None:
         return self._cleaner
 
     @cleaner.setter
@@ -144,7 +146,7 @@ class DocumentRoom(YRoom):
 class TransientRoom(YRoom):
     """A Y room for sharing state (e.g. awareness)."""
 
-    def __init__(self, room_id: str, log: Optional[Logger]):
+    def __init__(self, room_id: str, log: Logger | None):
         super().__init__(log=log)
 
         self._room_id = room_id

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -34,6 +34,7 @@ class DocumentRoom(YRoom):
 
         self._save_delay = save_delay
 
+        self._lock = asyncio.Lock()
         self._cleaner: Optional[asyncio.Task] = None
         self._saving_document: Optional[asyncio.Task] = None
 
@@ -44,6 +45,10 @@ class DocumentRoom(YRoom):
     @property
     def room_id(self) -> str:
         return self._room_id
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        return self._lock
 
     @property
     def cleaner(self) -> Optional[asyncio.Task]:

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -66,7 +66,7 @@ class DocumentRoom(YRoom):
 
     async def initialize(self) -> None:
         async with self._lock:
-            if self.ready: # type: ignore[has-type]
+            if self.ready:  # type: ignore[has-type]
                 return
 
             self.log.info("Initializing room %s", self._room_id)

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -1,0 +1,67 @@
+from logging import Logger
+from typing import Optional
+
+from ypy_websocket.websocket_server import YRoom
+from ypy_websocket.ystore import BaseYStore
+
+from jupyter_ydoc import ydocs as YDOCS
+
+from .loaders import FileLoader
+from .utils import decode_file_path
+
+YFILE = YDOCS["file"]
+
+class DocumentRoom(YRoom):
+    """A Y room for a possibly stored document (e.g. a notebook)."""
+
+    def __init__(self, room_id: str, file: FileLoader, ystore: Optional[BaseYStore], log: Optional[Logger]):
+        super().__init__(ready=False, ystore=ystore, log=log)
+        self._room_id: str = room_id
+        self._file: FileLoader = file
+        self._document = YDOCS.get(type, YFILE)(self.ydoc)
+
+        # Add room to the file for loading content
+        self._file.add_room(self._room_id, self)
+
+        # save the document when changed
+        self._document.observe(self._on_document_change)
+
+    async def initialize(self):
+        await self.set_document_content()
+        self._ready = True
+    
+    def clean_room(self) -> None:
+        self._document.unobserve()
+        self._file.remove_room(self._room_id)
+
+    def clear_dirty_flag(self) -> None:
+        self.room.document.dirty = False
+
+    async def set_document_content(self) -> None:
+        format, file_type, _ = decode_file_path(self._room_id)
+        model = await self._file.load_file_data(format, file_type, True)
+        self.room.document.source = model["content"]
+        self.clear_dirty_flag()
+    
+
+
+    def _on_document_change(self, target, event):
+        if target == "state" and "dirty" in event.keys:
+            dirty = event.keys["dirty"]["newValue"]
+            if not dirty:
+                # we cleared the dirty flag, nothing to save
+                return
+        
+        format, file_type, _ = decode_file_path(self._room_id)
+        self._file.save_content({
+            "format": format,
+            "type": file_type,
+            "content": self._document.source
+        })
+
+
+class TransientRoom(YRoom):
+    """A Y room for sharing state (e.g. awareness)."""
+
+    def __init__(self, log: Optional[Logger]):
+        super().__init__(log=log)

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -66,7 +66,7 @@ class DocumentRoom(YRoom):
 
     async def initialize(self) -> None:
         async with self._lock:
-            if self.ready:
+            if self.ready: # type: ignore[has-type]
                 return
 
             self.log.info("Initializing room %s", self._room_id)

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -31,7 +31,7 @@ class DocumentRoom(YRoom):
         self._room_id: str = room_id
         self._file_format: str = file_format
         self._file_type: str = file_type
-        self._last_modified: str = None
+        self._last_modified: Any = None
         self._file: FileLoader = file
         self._document = YDOCS.get(self._file_type, YFILE)(self.ydoc)
 
@@ -122,6 +122,8 @@ class DocumentRoom(YRoom):
                 if self.ystore:
                     await self.ystore.encode_state_as_update(self.ydoc)
 
+            print("INITIALIZE: last_modified", model["last_modified"])
+            print("INITIALIZE: ", model)
             self._last_modified = model["last_modified"]
             self._document.dirty = False
             self.ready = True

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from logging import Logger
-from typing import Any, Optional
+from typing import Any
 
 from jupyter_ydoc import ydocs as YDOCS
 from ypy_websocket.websocket_server import YRoom

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -1,22 +1,31 @@
 import asyncio
 from logging import Logger
-from typing import Optional
-
-from ypy_websocket.websocket_server import YRoom
-from ypy_websocket.ystore import BaseYStore, YDocNotFound
+from typing import Any, Optional
 
 from jupyter_ydoc import ydocs as YDOCS
+from ypy_websocket.websocket_server import YRoom
+from ypy_websocket.ystore import BaseYStore, YDocNotFound
 
 from .loaders import FileLoader
 
 YFILE = YDOCS["file"]
 
+
 class DocumentRoom(YRoom):
     """A Y room for a possibly stored document (e.g. a notebook)."""
 
-    def __init__(self, room_id: str, file_format: str, file_type: str, file: FileLoader, ystore: Optional[BaseYStore], log: Optional[Logger], save_delay: int = None):
+    def __init__(
+        self,
+        room_id: str,
+        file_format: str,
+        file_type: str,
+        file: FileLoader,
+        ystore: Optional[BaseYStore],
+        log: Optional[Logger],
+        save_delay: Optional[int] = None,
+    ):
         super().__init__(ready=False, ystore=ystore, log=log)
-        
+
         self._room_id: str = room_id
         self._file_format: str = file_format
         self._file_type: str = file_type
@@ -25,8 +34,8 @@ class DocumentRoom(YRoom):
 
         self._save_delay = save_delay
 
-        self._cleaner: asyncio.Task = None
-        self._saving_document: asyncio.Task = None
+        self._cleaner: Optional[asyncio.Task] = None
+        self._saving_document: Optional[asyncio.Task] = None
 
         # Listen for document changes
         self._document.observe(self._on_document_change)
@@ -35,22 +44,25 @@ class DocumentRoom(YRoom):
     @property
     def room_id(self) -> str:
         return self._room_id
-    
+
     @property
-    def cleaner(self) -> asyncio.Task:
+    def cleaner(self) -> Optional[asyncio.Task]:
         return self._cleaner
-    
+
     @cleaner.setter
     def cleaner(self, value: asyncio.Task) -> None:
         self._cleaner = value
-    
-    def __del__(self) -> None:
+
+    def _clean(self) -> None:
+        super()._clean()
         # TODO: Should we cancel or wait ?
-        self._saving_document.cancel()
+        if self._saving_document:
+            self._saving_document.cancel()
         self._document.unobserve()
         self._file.unobserve(self.room_id)
-    
-    async def initialize(self):
+
+    async def initialize(self) -> None:
+        self.log.info("Initializing room %s", self._room_id)
         model = await self._file.load_content(self._file_format, self._file_type, True)
 
         # try to apply Y updates from the YStore for this document
@@ -58,60 +70,67 @@ class DocumentRoom(YRoom):
         if self.ystore is not None:
             try:
                 await self.ystore.apply_updates(self.ydoc)
+                self.log.info(
+                    "Content in room %s loaded from the ystore %s",
+                    self._room_id,
+                    self.ystore.__class__.__name__,
+                )
                 read_from_source = False
             except YDocNotFound:
                 # YDoc not found in the YStore, create the document from the source file (no change history)
                 pass
-        
+
         if not read_from_source:
             # if YStore updates and source file are out-of-sync, resync updates with source
             if self._document.source != model["content"]:
+                self.log.info(
+                    "Content in file %s is out-of-sync with the ystore %s",
+                    self._file.path,
+                    self.ystore.__class__.__name__,
+                )
                 read_from_source = True
 
         if read_from_source:
+            self.log.info("Content in room %s loaded from file %s", self._room_id, self._file.path)
             self._document.source = model["content"]
-            
+
             if self.ystore:
                 await self.ystore.encode_state_as_update(self.ydoc)
-        
+
         self._document.dirty = False
         self.ready = True
-    
-    async def _set_document_content(self) -> None:
-        model = await self._file.load_content(self._file_format, self._file_type, True)
-        self._document.source = model["content"]
-        self._document.dirty = False
-    
-    def _on_content_change(self, event):
-        if event == "changed":
-            self._set_document_content()
 
-    def _on_document_change(self, target, event):
+    async def _on_content_change(self, event: str) -> None:
+        if event == "changed":
+            self.log.info("Overwriting the content in room %s", self._room_id)
+            model = await self._file.load_content(self._file_format, self._file_type, True)
+            self._document.source = model["content"]
+            self._document.dirty = False
+
+    def _on_document_change(self, target: str, event: Any) -> None:
         if target == "state" and "dirty" in event.keys:
             dirty = event.keys["dirty"]["newValue"]
             if not dirty:
                 # we cleared the dirty flag, nothing to save
                 return
-        
+
         if self._saving_document is not None and not self._saving_document.done():
             # the document is being saved, cancel that
             self._saving_document.cancel()
             self._saving_document = None
 
         self._saving_document = asyncio.create_task(self._maybe_save_document())
-    
-    async def _maybe_save_document(self):
+
+    async def _maybe_save_document(self) -> None:
         if self._save_delay is None:
             return
-        
+
         # save after X seconds of inactivity
         await asyncio.sleep(self._save_delay)
 
-        await self._file.save_content({
-            "format": self._file_format,
-            "type": self._file_type,
-            "content": self._document.source
-        })
+        await self._file.save_content(
+            {"format": self._file_format, "type": self._file_type, "content": self._document.source}
+        )
         self._document.dirty = False
 
 

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -8,27 +8,29 @@ from ypy_websocket.ystore import BaseYStore, YDocNotFound
 from jupyter_ydoc import ydocs as YDOCS
 
 from .loaders import FileLoader
-from .utils import decode_file_path
 
 YFILE = YDOCS["file"]
 
 class DocumentRoom(YRoom):
     """A Y room for a possibly stored document (e.g. a notebook)."""
 
-    def __init__(self, room_id: str, file: FileLoader, ystore: Optional[BaseYStore], log: Optional[Logger]):
+    def __init__(self, room_id: str, file_format: str, file_type: str, file: FileLoader, ystore: Optional[BaseYStore], log: Optional[Logger], save_delay: int = None):
         super().__init__(ready=False, ystore=ystore, log=log)
         
         self._room_id: str = room_id
+        self._file_format: str = file_format
+        self._file_type: str = file_type
         self._file: FileLoader = file
-        self._document = YDOCS.get(type, YFILE)(self.ydoc)
+        self._document = YDOCS.get(self._file_type, YFILE)(self.ydoc)
 
-        # Add room to the file for loading content
-        self._file.add_room(self.room_id, self)
+        self._save_delay = save_delay
 
         self._cleaner: asyncio.Task = None
+        self._saving_document: asyncio.Task = None
 
-        # save the document when changed
+        # Listen for document changes
         self._document.observe(self._on_document_change)
+        self._file.observe(self.room_id, self._on_content_change)
 
     @property
     def room_id(self) -> str:
@@ -43,13 +45,13 @@ class DocumentRoom(YRoom):
         self._cleaner = value
     
     def __del__(self) -> None:
+        # TODO: Should we cancel or wait ?
+        self._saving_document.cancel()
         self._document.unobserve()
-        self._file.remove_room(self.room_id)
+        self._file.unobserve(self.room_id)
     
     async def initialize(self):
-        format, file_type, _ = decode_file_path(self._room_id)
-        model = await self._file.load_file_data(format, file_type, True)
-        print(model)
+        model = await self._file.load_content(self._file_format, self._file_type, True)
 
         # try to apply Y updates from the YStore for this document
         read_from_source = True
@@ -68,21 +70,22 @@ class DocumentRoom(YRoom):
 
         if read_from_source:
             self._document.source = model["content"]
+            
             if self.ystore:
                 await self.ystore.encode_state_as_update(self.ydoc)
         
-        await self.set_document_content()
-        self._ready = True
-
-    def clear_dirty_flag(self) -> None:
         self._document.dirty = False
-
-    async def set_document_content(self) -> None:
-        format, file_type, _ = decode_file_path(self._room_id)
-        model = await self._file.load_file_data(format, file_type, True)
-        self._document.source = model["content"]
-        self.clear_dirty_flag()
+        self.ready = True
     
+    async def _set_document_content(self) -> None:
+        model = await self._file.load_content(self._file_format, self._file_type, True)
+        self._document.source = model["content"]
+        self._document.dirty = False
+    
+    def _on_content_change(self, event):
+        if event == "changed":
+            self._set_document_content()
+
     def _on_document_change(self, target, event):
         if target == "state" and "dirty" in event.keys:
             dirty = event.keys["dirty"]["newValue"]
@@ -90,16 +93,36 @@ class DocumentRoom(YRoom):
                 # we cleared the dirty flag, nothing to save
                 return
         
-        format, file_type, _ = decode_file_path(self._room_id)
-        self._file.save_content({
-            "format": format,
-            "type": file_type,
+        if self._saving_document is not None and not self._saving_document.done():
+            # the document is being saved, cancel that
+            self._saving_document.cancel()
+            self._saving_document = None
+
+        self._saving_document = asyncio.create_task(self._maybe_save_document())
+    
+    async def _maybe_save_document(self):
+        if self._save_delay is None:
+            return
+        
+        # save after X seconds of inactivity
+        await asyncio.sleep(self._save_delay)
+
+        await self._file.save_content({
+            "format": self._file_format,
+            "type": self._file_type,
             "content": self._document.source
         })
+        self._document.dirty = False
 
 
 class TransientRoom(YRoom):
     """A Y room for sharing state (e.g. awareness)."""
 
-    def __init__(self, log: Optional[Logger]):
+    def __init__(self, room_id: str, log: Optional[Logger]):
         super().__init__(log=log)
+
+        self._room_id = room_id
+
+    @property
+    def room_id(self) -> str:
+        return self._room_id

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -194,7 +194,7 @@ class DocumentRoom(YRoom):
             document. This tasks are debounced (60 seconds by default) so we
             need to cancel previous tasks before creating a new one.
         """
-        if self._flag.updating == True:
+        if self._flag.updating:
             return
 
         if self._saving_document is not None and not self._saving_document.done():

--- a/jupyter_collaboration/stores.py
+++ b/jupyter_collaboration/stores.py
@@ -3,7 +3,6 @@
 
 from traitlets import Int, Unicode
 from traitlets.config import LoggingConfigurable
-
 from ypy_websocket.ystore import SQLiteYStore as _SQLiteYStore
 from ypy_websocket.ystore import TempFileYStore as _TempFileYStore
 

--- a/jupyter_collaboration/stores.py
+++ b/jupyter_collaboration/stores.py
@@ -1,0 +1,33 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from traitlets import Int, Unicode
+from traitlets.config import LoggingConfigurable
+
+from ypy_websocket.ystore import SQLiteYStore as _SQLiteYStore
+from ypy_websocket.ystore import TempFileYStore as _TempFileYStore
+
+
+class TempFileYStore(_TempFileYStore):
+    prefix_dir = "jupyter_ystore_"
+
+
+class SQLiteYStoreMetaclass(type(LoggingConfigurable), type(_SQLiteYStore)):  # type: ignore
+    pass
+
+
+class SQLiteYStore(LoggingConfigurable, _SQLiteYStore, metaclass=SQLiteYStoreMetaclass):
+    db_path = Unicode(
+        ".jupyter_ystore.db",
+        config=True,
+        help="""The path to the YStore database. Defaults to '.jupyter_ystore.db' in the current
+        directory.""",
+    )
+
+    document_ttl = Int(
+        None,
+        allow_none=True,
+        config=True,
+        help="""The document time-to-live in seconds. Defaults to None (document history is never
+        cleared).""",
+    )

--- a/jupyter_collaboration/utils.py
+++ b/jupyter_collaboration/utils.py
@@ -2,9 +2,32 @@ from typing import Tuple
 
 
 def decode_file_path(path: str) -> Tuple[str, str, str]:
+    """
+    Decodes a file path. The file path is composed by the format,
+    content type, and path or file id separated by ':'.
+
+        Parameters:
+            path (str): File path.
+
+        Returns:
+            components (Tuple[str, str, str]): A tuple with the format,
+                content type, and path or file id.
+    """
     format, file_type, file_id = path.split(":", 2)
     return (format, file_type, file_id)
 
 
 def encode_file_path(format: str, file_type: str, file_id: str) -> str:
+    """
+    Encodes a file path. The file path is composed by the format,
+    content type, and path or file id separated by ':'.
+
+        Parameters:
+            format (str): File format.
+            type (str): Content type.
+            path (str): Path or file id.
+
+        Returns:
+            path (str): File path.
+    """
     return f"{format}:{file_type}:{file_id}"

--- a/jupyter_collaboration/utils.py
+++ b/jupyter_collaboration/utils.py
@@ -1,0 +1,7 @@
+
+def decode_file_path(path):
+	format, file_type, file_id = path.split(":", 2)
+	return (format, file_type, file_id)
+
+def encode_file_path(format, file_type, file_id):
+	return f"{format}:{file_type}:{file_id}"

--- a/jupyter_collaboration/utils.py
+++ b/jupyter_collaboration/utils.py
@@ -1,7 +1,7 @@
 
-def decode_file_path(path):
+def decode_file_path(path: str):
 	format, file_type, file_id = path.split(":", 2)
 	return (format, file_type, file_id)
 
-def encode_file_path(format, file_type, file_id):
+def encode_file_path(format: str, file_type: str, file_id: str):
 	return f"{format}:{file_type}:{file_id}"

--- a/jupyter_collaboration/utils.py
+++ b/jupyter_collaboration/utils.py
@@ -1,7 +1,10 @@
+from typing import Tuple
 
-def decode_file_path(path: str):
-	format, file_type, file_id = path.split(":", 2)
-	return (format, file_type, file_id)
 
-def encode_file_path(format: str, file_type: str, file_id: str):
-	return f"{format}:{file_type}:{file_id}"
+def decode_file_path(path: str) -> Tuple[str, str, str]:
+    format, file_type, file_id = path.split(":", 2)
+    return (format, file_type, file_id)
+
+
+def encode_file_path(format: str, file_type: str, file_id: str) -> str:
+    return f"{format}:{file_type}:{file_id}"

--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -1,10 +1,13 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DocumentChange, ISharedDocument, YDocument } from '@jupyter/ydoc';
+import { showDialog, Dialog } from '@jupyterlab/apputils';
 import { URLExt } from '@jupyterlab/coreutils';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { Contents, Drive, User } from '@jupyterlab/services';
+
+import { DocumentChange, ISharedDocument, YDocument } from '@jupyter/ydoc';
+
 import { WebSocketProvider } from './yprovider';
 import {
   ICollaborativeDrive,
@@ -138,6 +141,23 @@ export class YDrive extends Drive implements ICollaborativeDrive {
           this._providers.delete(key);
         }
       });
+
+      for (const provider of this._providers.keys()) {
+        if (provider === key) {
+          continue;
+        }
+        const path = provider.split(':')[2];
+
+        if (options.path === path) {
+          showDialog({
+            title: this._trans.__('Warning'),
+            body: this._trans.__(
+              'Opening a document with multiple views simultaneously is not supported.Please, close one view otherwise, you might lose some of your changes.'
+            ),
+            buttons: [Dialog.okButton()]
+          });
+        }
+      }
     } catch (error) {
       // Falling back to the contents API if opening the websocket failed
       //  This may happen if the shared document is not a YDocument.

--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -138,6 +138,10 @@ export class YDrive extends Drive implements ICollaborativeDrive {
           this._providers.delete(key);
         }
       });
+
+      sharedModel.changed.connect((sender, args) => {
+        console.debug("ARGS:", args);
+      });
     } catch (error) {
       // Falling back to the contents API if opening the websocket failed
       //  This may happen if the shared document is not a YDocument.

--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -138,10 +138,6 @@ export class YDrive extends Drive implements ICollaborativeDrive {
           this._providers.delete(key);
         }
       });
-
-      sharedModel.changed.connect((sender, args) => {
-        console.debug("ARGS:", args);
-      });
     } catch (error) {
       // Falling back to the contents API if opening the websocket failed
       //  This may happen if the shared document is not a YDocument.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ exclude=[
     "^binder/jupyter_config\\.py$",
 ]
 check_untyped_defs = true
-disallow_any_generics = true
+disallow_any_generics = false
 disallow_incomplete_defs = true
 disallow_untyped_decorators = true
 no_implicit_optional = true
@@ -153,7 +153,7 @@ strict_equality = true
 strict_optional = true
 warn_unused_configs = true
 warn_redundant_casts = true
-warn_return_any = true
+warn_return_any = false
 warn_unused_ignores = true
 ignore_missing_imports = true
 


### PR DESCRIPTION
Creates a new FileLoader class to separate the logic of watching files from the WebSocketHandler.

# Code changes:
* Split classes in different files
* Creates a new FileLoader class to centralize loading, saving, and watching files.
   Multiple rooms can get an instance of this class and use it to access the content safely since we can create a single lock by file to ensure two rooms are not accessing the same file simultaneously.
* Updates the DocumentRoom to use the FileLoader.

# TODO:
- [x] Create an abstract class for FileLoader to extend from.
    * Some extensions (like jupytercad) may want their own loader.
    * Allow registering new file loaders.
- [ ] Add documentation