### PR TITLE
Display remote user cursors

### DIFF
--- a/packages/collaboration-extension/package.json
+++ b/packages/collaboration-extension/package.json
@@ -57,6 +57,7 @@
     "@jupyter/docprovider": "^1.0.0-alpha.4",
     "@jupyterlab/application": "^4.0.0-alpha.22",
     "@jupyterlab/apputils": "^4.0.0-alpha.22",
+    "@jupyterlab/codemirror": "^4.0.0-alpha.22",
     "@jupyterlab/coreutils": "^6.0.0-alpha.22",
     "@jupyterlab/filebrowser": "^4.0.0-alpha.22",
     "@jupyterlab/services": "^7.0.0-alpha.22",
@@ -76,10 +77,6 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "^4.1.2",
     "typescript": "~5.0.2"
-  },
-  "resolutions": {
-    "@codemirror/state": "6.2.0",
-    "@codemirror/view": "6.7.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/collaboration-extension/package.json
+++ b/packages/collaboration-extension/package.json
@@ -76,6 +76,10 @@
     "rimraf": "^4.1.2",
     "typescript": "~5.0.2"
   },
+  "resolutions": {
+    "@codemirror/state": "6.2.0",
+    "@codemirror/view": "6.7.3"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -93,6 +97,14 @@
       "@jupyterlab/filebrowser-extension:defaultFileBrowser"
     ],
     "sharedPackages": {
+      "@codemirror/state": {
+        "bundled": true,
+        "singleton": true
+      },
+      "@codemirror/view": {
+        "bundled": true,
+        "singleton": true
+      },
       "@jupyter/collaboration": {
         "bundled": true,
         "singleton": true
@@ -102,6 +114,14 @@
         "singleton": true
       },
       "@jupyter/ydoc": {
+        "bundled": false,
+        "singleton": true
+      },
+      "y-protocols": {
+        "bundled": false,
+        "singleton": true
+      },
+      "yjs": {
         "bundled": false,
         "singleton": true
       }

--- a/packages/collaboration-extension/package.json
+++ b/packages/collaboration-extension/package.json
@@ -38,8 +38,9 @@
   ],
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",
-    "build:lib": "tsc",
-    "build:prod": "jlpm run clean && jlpm run build:lib && jlpm run build:labextension",
+    "build:lib": "tsc --sourceMap",
+    "build:lib:prod": "tsc",
+    "build:prod": "jlpm run clean && jlpm run build:lib:prod && jlpm run build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "clean": "jlpm run clean:lib",
@@ -98,11 +99,11 @@
     ],
     "sharedPackages": {
       "@codemirror/state": {
-        "bundled": true,
+        "bundled": false,
         "singleton": true
       },
       "@codemirror/view": {
-        "bundled": true,
+        "bundled": false,
         "singleton": true
       },
       "@jupyter/collaboration": {

--- a/packages/collaboration-extension/src/collaboration.ts
+++ b/packages/collaboration-extension/src/collaboration.ts
@@ -11,10 +11,15 @@ import {
 } from '@jupyterlab/application';
 import { DOMUtils } from '@jupyterlab/apputils';
 import {
+  EditorExtensionRegistry,
+  IEditorExtensionRegistry
+} from '@jupyterlab/codemirror';
+import {
   CollaboratorsPanel,
   IAwareness,
   IGlobalAwareness,
   IUserMenu,
+  remoteUserCursors,
   RendererUserMenu,
   UserInfoPanel,
   UserMenu
@@ -154,5 +159,25 @@ export const rtcPanelPlugin: JupyterFrontEndPlugin<void> = {
     );
     collaboratorsPanel.title.label = trans.__('Online Collaborators');
     userPanel.addWidget(collaboratorsPanel);
+  }
+};
+
+export const userEditorCursors: JupyterFrontEndPlugin<void> = {
+  id: '@jupyter/collaboration-extension:userEditorCursors',
+  autoStart: true,
+  requires: [IEditorExtensionRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    extensions: IEditorExtensionRegistry
+  ): void => {
+    extensions.addExtension({
+      name: 'remote-user-cursors',
+      factory(options) {
+        const { awareness, ysource: ytext } = options.model.sharedModel as any;
+        return EditorExtensionRegistry.createImmutableExtension(
+          remoteUserCursors({ awareness, ytext })
+        );
+      }
+    });
   }
 };

--- a/packages/collaboration-extension/src/collaboration.ts
+++ b/packages/collaboration-extension/src/collaboration.ts
@@ -29,7 +29,7 @@ import { Menu, MenuBar } from '@lumino/widgets';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 import { IStateDB, StateDB } from '@jupyterlab/statedb';
-import { ITranslator } from '@jupyterlab/translation';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 import * as Y from 'yjs';
 import { Awareness } from 'y-protocols/awareness';
@@ -40,7 +40,7 @@ import { WebsocketProvider } from 'y-websocket';
  */
 export const userMenuPlugin: JupyterFrontEndPlugin<IUserMenu> = {
   id: '@jupyter/collaboration-extension:userMenu',
-  autoStart: true,
+  description: 'Provide connected user menu.',
   requires: [],
   provides: IUserMenu,
   activate: (app: JupyterFrontEnd): IUserMenu => {
@@ -55,6 +55,7 @@ export const userMenuPlugin: JupyterFrontEndPlugin<IUserMenu> = {
  */
 export const menuBarPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyter/collaboration-extension:userMenuBar',
+  description: 'Add user menu to the interface.',
   autoStart: true,
   requires: [IUserMenu],
   activate: async (app: JupyterFrontEnd, menu: IUserMenu): Promise<void> => {
@@ -80,7 +81,7 @@ export const menuBarPlugin: JupyterFrontEndPlugin<void> = {
  */
 export const rtcGlobalAwarenessPlugin: JupyterFrontEndPlugin<IAwareness> = {
   id: '@jupyter/collaboration-extension:rtcGlobalAwareness',
-  autoStart: true,
+  description: 'Add global awareness to share working document of users.',
   requires: [IStateDB],
   provides: IGlobalAwareness,
   activate: (app: JupyterFrontEnd, state: StateDB): IAwareness => {
@@ -125,16 +126,18 @@ export const rtcGlobalAwarenessPlugin: JupyterFrontEndPlugin<IAwareness> = {
  */
 export const rtcPanelPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyter/collaboration-extension:rtcPanel',
+  description: 'Add side panel to display all currently connected users.',
   autoStart: true,
-  requires: [IGlobalAwareness, ITranslator],
+  requires: [IGlobalAwareness],
+  optional: [ITranslator],
   activate: (
     app: JupyterFrontEnd,
     awareness: Awareness,
-    translator: ITranslator
+    translator: ITranslator | null
   ): void => {
     const { user } = app.serviceManager;
 
-    const trans = translator.load('jupyter_collaboration');
+    const trans = (translator ?? nullTranslator).load('jupyter_collaboration');
 
     const userPanel = new SidePanel();
     userPanel.id = DOMUtils.createDomID();
@@ -164,6 +167,8 @@ export const rtcPanelPlugin: JupyterFrontEndPlugin<void> = {
 
 export const userEditorCursors: JupyterFrontEndPlugin<void> = {
   id: '@jupyter/collaboration-extension:userEditorCursors',
+  description:
+    'Add CodeMirror extension to display remote user cursors and selections.',
   autoStart: true,
   requires: [IEditorExtensionRegistry],
   activate: (

--- a/packages/collaboration-extension/src/index.ts
+++ b/packages/collaboration-extension/src/index.ts
@@ -12,7 +12,8 @@ import {
   userMenuPlugin,
   menuBarPlugin,
   rtcGlobalAwarenessPlugin,
-  rtcPanelPlugin
+  rtcPanelPlugin,
+  userEditorCursors
 } from './collaboration';
 
 /**
@@ -23,7 +24,8 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   userMenuPlugin,
   menuBarPlugin,
   rtcGlobalAwarenessPlugin,
-  rtcPanelPlugin
+  rtcPanelPlugin,
+  userEditorCursors
 ];
 
 export default plugins;

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -53,6 +53,7 @@
     "yjs": "^13.5.40"
   },
   "devDependencies": {
+    "@types/react": "^18.0.27",
     "rimraf": "^4.1.2",
     "typescript": "~5.0.2"
   },

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -39,6 +39,8 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@codemirror/state": "^6.2.0",
+    "@codemirror/view": "^6.7.0",
     "@jupyterlab/apputils": "^4.0.0-alpha.22",
     "@jupyterlab/coreutils": "^6.0.0-alpha.22",
     "@jupyterlab/services": "^7.0.0-alpha.22",

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -59,7 +59,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "jupyterlab": {},
   "typedoc": {
     "entryPoint": "./src/index.ts",
     "readmeFile": "./README.md",

--- a/packages/collaboration/src/cursors.ts
+++ b/packages/collaboration/src/cursors.ts
@@ -1,0 +1,217 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Annotation,
+  EditorSelection,
+  Extension,
+  Facet
+} from '@codemirror/state';
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  layer,
+  LayerMarker,
+  RectangleMarker,
+  ViewPlugin,
+  ViewUpdate
+} from '@codemirror/view';
+import { Awareness } from 'y-protocols/awareness';
+import {
+  compareRelativePositions,
+  createAbsolutePositionFromRelativePosition,
+  createRelativePositionFromJSON,
+  createRelativePositionFromTypeIndex,
+  Text
+} from 'yjs';
+
+/*
+  Add widget to codemirror 6 editors displaying collaboratros.
+
+  This code is inspired by https://github.com/yjs/y-codemirror.next/blob/main/src/y-remote-selections.js licensed under MIT License by Kevin Jahns
+ */
+
+/**
+ * Yjs document objects
+ */
+export type EditorAwareness = {
+  /**
+   * User related information
+   */
+  awareness: Awareness;
+  /**
+   * Shared editor source
+   */
+  ytext: Text;
+};
+
+/**
+ * Facet storing the Yjs document objects
+ */
+const editorAwarenessFacet = Facet.define<EditorAwareness, EditorAwareness>({
+  combine(configs: readonly EditorAwareness[]) {
+    return configs[configs.length - 1];
+  }
+});
+
+/**
+ * Remote selection theme
+ */
+const remoteSelectionTheme = EditorView.baseTheme({
+  '.jp-remote-cursors': {
+    'background-color': 'pink'
+  }
+});
+
+// TODO fix which user needs update
+const remoteSelectionsAnnotation = Annotation.define();
+
+const remoteCursorsLayer = layer({
+  above: true,
+  markers(view) {
+    const { awareness, ytext } = view.state.facet(editorAwarenessFacet);
+    const ydoc = ytext.doc!;
+    const cursors: LayerMarker[] = [];
+    awareness.getStates().forEach((state, clientID) => {
+      if (clientID === awareness.doc.clientID) {
+        return;
+      }
+
+      const cursor = state.cursor;
+      if (cursor === null || cursor.anchor === null || cursor.head === null) {
+        return;
+      }
+
+      const anchor = createAbsolutePositionFromRelativePosition(
+        cursor.anchor,
+        ydoc
+      );
+      const head = createAbsolutePositionFromRelativePosition(
+        cursor.head,
+        ydoc
+      );
+      if (
+        anchor === null ||
+        head === null ||
+        anchor.type !== ytext ||
+        head.type !== ytext
+      ) {
+        return;
+      }
+
+      const className = 'jp-remote-cursor';
+      const cursor_ = EditorSelection.cursor(
+        head.index,
+        head.index > anchor.index ? -1 : 1
+      );
+      for (const piece of RectangleMarker.forRange(view, className, cursor_)) {
+        cursors.push(piece);
+      }
+    });
+    return cursors;
+  },
+  update(update, layer) {
+    return !!update.transactions.find(t =>
+      t.annotation(remoteSelectionsAnnotation)
+    );
+  },
+  class: 'jp-remote-cursors'
+});
+
+const showCollaborators = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    editorAwareness: EditorAwareness;
+    _listener: (t: {
+      added: Array<any>;
+      updated: Array<any>;
+      removed: Array<any>;
+    }) => void;
+
+    constructor(view: EditorView) {
+      this.editorAwareness = view.state.facet(editorAwarenessFacet);
+      this.decorations = Decoration.set([]);
+      this._listener = ({ added, updated, removed }) => {
+        const clients = added.concat(updated).concat(removed);
+        if (
+          clients.findIndex(
+            id => id !== this.editorAwareness.awareness.doc.clientID
+          ) >= 0
+        ) {
+          view.dispatch({ annotations: [remoteSelectionsAnnotation.of([])] });
+        }
+      };
+
+      this.editorAwareness.awareness.on('change', this._listener);
+    }
+
+    destroy(): void {
+      this.editorAwareness.awareness.off('change', this._listener);
+    }
+
+    /**
+     * Communicate the current user cursor position to all remotes
+     */
+    update(update: ViewUpdate): void {
+      if (!update.docChanged && !update.selectionSet) {
+        return;
+      }
+
+      const { awareness, ytext } = this.editorAwareness;
+      const localAwarenessState = awareness.getLocalState();
+
+      // set local awareness state (update cursors)
+      if (localAwarenessState !== null) {
+        const hasFocus =
+          update.view.hasFocus && update.view.dom.ownerDocument.hasFocus();
+        const selection = update.state.selection.main;
+
+        if (hasFocus && selection !== null) {
+          const currentAnchor =
+            localAwarenessState.cursor === null
+              ? null
+              : createRelativePositionFromJSON(
+                  localAwarenessState.cursor.anchor
+                );
+          const currentHead =
+            localAwarenessState.cursor === null
+              ? null
+              : createRelativePositionFromJSON(localAwarenessState.cursor.head);
+
+          const anchor = createRelativePositionFromTypeIndex(
+            ytext,
+            selection.anchor
+          );
+          const head = createRelativePositionFromTypeIndex(
+            ytext,
+            selection.head
+          );
+          if (
+            localAwarenessState.cursor === null ||
+            !compareRelativePositions(currentAnchor, anchor) ||
+            !compareRelativePositions(currentHead, head)
+          ) {
+            awareness.setLocalStateField('cursor', {
+              anchor,
+              head
+            });
+          }
+        }
+      }
+    }
+  },
+  {
+    provide: plugin => {
+      return [remoteCursorsLayer];
+    }
+  }
+);
+
+export function remoteUserCursors(config: EditorAwareness): Extension {
+  return [
+    editorAwarenessFacet.of(config),
+    remoteSelectionTheme,
+    showCollaborators
+  ];
+}

--- a/packages/collaboration/src/index.ts
+++ b/packages/collaboration/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './tokens';
+export * from './cursors';
 export * from './menu';
 export * from './userinfopanel';
 export * from './collaboratorspanel';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,14 +1324,247 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:^6.1.4, @codemirror/state@npm:^6.2.0":
+"@codemirror/autocomplete@npm:^6.0.0, @codemirror/autocomplete@npm:^6.3.2, @codemirror/autocomplete@npm:^6.4.0":
+  version: 6.4.2
+  resolution: "@codemirror/autocomplete@npm:6.4.2"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.6.0
+    "@lezer/common": ^1.0.0
+  peerDependencies:
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    "@lezer/common": ^1.0.0
+  checksum: c6cc4edb1c412153e6f6f27926674d7f1d386d1f30d6d4f60c5b52bfa0105870b0c70449b69891937bcf082340d8b0fa6d1f9f28f5eb60adc2974ed4c73aadc1
+  languageName: node
+  linkType: hard
+
+"@codemirror/commands@npm:^6.1.0":
+  version: 6.2.2
+  resolution: "@codemirror/commands@npm:6.2.2"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.2.0
+    "@codemirror/view": ^6.0.0
+    "@lezer/common": ^1.0.0
+  checksum: d3aa1ca8cbd7b9434eedba6b6d783411670796bf6ab61990afc4fd0c04645189fe4dd55bb95e23b943e9089f9739bc7e92aa4b2ac3eac09cfa2b91a45f608d3e
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-cpp@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "@codemirror/lang-cpp@npm:6.0.2"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@lezer/cpp": ^1.0.0
+  checksum: bb9eba482cca80037ce30c7b193cf45eff19ccbb773764fddf2071756468ecc25aa53c777c943635054f89095b0247b9b50c339e107e41e68d34d12a7295f9a9
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-css@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "@codemirror/lang-css@npm:6.1.1"
+  dependencies:
+    "@codemirror/autocomplete": ^6.0.0
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@lezer/css": ^1.0.0
+  checksum: 9b0bf7c7544fb604b67325689d783981e4099560f577bc1f10c52cb18e9d275ebdbdbd3f335a1dbb9c4910c36320f74ca015fc92ef99f930ecb9d481a2bf3511
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-html@npm:^6.0.0, @codemirror/lang-html@npm:^6.4.0":
+  version: 6.4.2
+  resolution: "@codemirror/lang-html@npm:6.4.2"
+  dependencies:
+    "@codemirror/autocomplete": ^6.0.0
+    "@codemirror/lang-css": ^6.0.0
+    "@codemirror/lang-javascript": ^6.0.0
+    "@codemirror/language": ^6.4.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.2.2
+    "@lezer/common": ^1.0.0
+    "@lezer/css": ^1.1.0
+    "@lezer/html": ^1.3.0
+  checksum: 10eebf44f275867c9916639f55610214c305d27a8a8545c3fa2d9495cbac33eb9f8751fc6b78e83d957c49a4b446bbee959bdf3eb497e88a05796aca02ed773b
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-java@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@codemirror/lang-java@npm:6.0.1"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@lezer/java": ^1.0.0
+  checksum: 4679104683cbffcd224ac04c7e5d144b787494697b26470b07017259035b7bb3fa62609d9a61bfbc566f1756d9f972f9f26d96a3c1362dd48881c1172f9a914d
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-javascript@npm:^6.0.0, @codemirror/lang-javascript@npm:^6.1.0":
+  version: 6.1.4
+  resolution: "@codemirror/lang-javascript@npm:6.1.4"
+  dependencies:
+    "@codemirror/autocomplete": ^6.0.0
+    "@codemirror/language": ^6.6.0
+    "@codemirror/lint": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    "@lezer/common": ^1.0.0
+    "@lezer/javascript": ^1.0.0
+  checksum: d550db179c522cd7c39d26815ee47ac4751656c856d42eeb3743e67482d4377692c4fcd3413b0e97c2c7070b6b10aaa582909c6234f42b04145d56efc49c8a6b
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-json@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@codemirror/lang-json@npm:6.0.1"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@lezer/json": ^1.0.0
+  checksum: e9e87d50ff7b81bd56a6ab50740b1dd54e9a93f1be585e1d59d0642e2148842ea1528ac7b7221eb4ddc7fe84bbc28065144cc3ab86f6e06c6aeb2d4b4e62acf1
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-markdown@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "@codemirror/lang-markdown@npm:6.1.0"
+  dependencies:
+    "@codemirror/lang-html": ^6.0.0
+    "@codemirror/language": ^6.3.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    "@lezer/common": ^1.0.0
+    "@lezer/markdown": ^1.0.0
+  checksum: faee880c5e695391fc5b92788d1500bed3f0cc3766c987077cdc1643cf38b97eb1774a29491a7a75064089478b895e7c8fe5a4f08ac93c9614ccbbe188f10b47
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-php@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@codemirror/lang-php@npm:6.0.1"
+  dependencies:
+    "@codemirror/lang-html": ^6.0.0
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@lezer/common": ^1.0.0
+    "@lezer/php": ^1.0.0
+  checksum: c003a29a426486453fdfddbf7302982fa2aa7f059bf6f1ce4cbf08341b0162eee5e2f50e0d71c418dcd358491631780156d846fe352754d042576172c5d86721
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-python@npm:^6.1.0":
+  version: 6.1.2
+  resolution: "@codemirror/lang-python@npm:6.1.2"
+  dependencies:
+    "@codemirror/autocomplete": ^6.3.2
+    "@codemirror/language": ^6.0.0
+    "@lezer/python": ^1.0.0
+  checksum: e822a1236fb3c2773e1889d4a24f8f2f7fb45ab8cf6e0521d311508a3eda19c4dcf4e2f943766b93545e673f3f0336725418e0bb48b3d9fb6a942339d164cfa5
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-rust@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@codemirror/lang-rust@npm:6.0.1"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@lezer/rust": ^1.0.0
+  checksum: 8a439944cb22159b0b3465ca4fa4294c69843219d5d30e278ae6df8e48f30a7a9256129723c025ec9b5e694d31a3560fb004300b125ffcd81c22d13825845170
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-sql@npm:^6.3.0":
+  version: 6.4.0
+  resolution: "@codemirror/lang-sql@npm:6.4.0"
+  dependencies:
+    "@codemirror/autocomplete": ^6.0.0
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 5981b08ff103ae4c36209617543be2ba811ffd26aa68632252ae8526e6c1b7436ff240221348247d3fd5eebb892a4040e7b0b6accbbc5c7968634fd2a9ba0559
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-wast@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@codemirror/lang-wast@npm:6.0.1"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 600d98d3ea6a4e99292244ed707e39a2abd9f3abf62cfeff5c819a0cc0c7e86b8c5b91e91c1b7ea21233d9ea09c41abe61d8a40b2547bb5db74239c6df857934
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-xml@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "@codemirror/lang-xml@npm:6.0.2"
+  dependencies:
+    "@codemirror/autocomplete": ^6.0.0
+    "@codemirror/language": ^6.4.0
+    "@codemirror/state": ^6.0.0
+    "@lezer/common": ^1.0.0
+    "@lezer/xml": ^1.0.0
+  checksum: e156ecafaa87e9b6ef4ab6812ccd00d8f3c6cb81f232837636b36336d80513b61936dfee6f4f6800574f236208b61e95a2abcb997cdcd7366585a6b796e0e13b
+  languageName: node
+  linkType: hard
+
+"@codemirror/language@npm:^6.0.0, @codemirror/language@npm:^6.3.0, @codemirror/language@npm:^6.4.0, @codemirror/language@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "@codemirror/language@npm:6.6.0"
+  dependencies:
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    "@lezer/common": ^1.0.0
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+    style-mod: ^4.0.0
+  checksum: bb9411620e2f231653a3f0c4429e0d19a3843bff5dbc117df4649d7bf783ec4ad809c0add8bc0887a4ec3f48b4f8f941621168e47d76101d5383f0d670af1722
+  languageName: node
+  linkType: hard
+
+"@codemirror/legacy-modes@npm:^6.3.0":
+  version: 6.3.2
+  resolution: "@codemirror/legacy-modes@npm:6.3.2"
+  dependencies:
+    "@codemirror/language": ^6.0.0
+  checksum: fa5f5477fb9e19267251e2ecd3de8c1a4c2512813555bb60111dce3951f2c3f6080a2985a573b7542534ba1d2c34115f7e39ee23fdf8f6f81db6f8ce447c1efc
+  languageName: node
+  linkType: hard
+
+"@codemirror/lint@npm:^6.0.0":
+  version: 6.2.0
+  resolution: "@codemirror/lint@npm:6.2.0"
+  dependencies:
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    crelt: ^1.0.5
+  checksum: b97e55a07bca9f7e357e495853ba189ae0ff7dfe7e7ae445d7a0d6c6926ec792c7f5c6b6c13a1f137fd9fedf44a6624e9d500f76d0d46a3c3e9d19c2cda9d28a
+  languageName: node
+  linkType: hard
+
+"@codemirror/search@npm:^6.2.0":
+  version: 6.3.0
+  resolution: "@codemirror/search@npm:6.3.0"
+  dependencies:
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    crelt: ^1.0.5
+  checksum: b757eebbb541c9d74fe36ccfdd03bc3e4e7aebb08b491e207d5898f24aaa612558c393ba49de5bf375972f5774de817fcfbad1ac551dda1a34badb41cf130d36
+  languageName: node
+  linkType: hard
+
+"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.1.4, @codemirror/state@npm:^6.2.0":
   version: 6.2.0
   resolution: "@codemirror/state@npm:6.2.0"
   checksum: fdc99c773dc09c700dd02bf918f06132aa8d3069c262cc4eb6ca5c810ce24ae2d7e90719ae7630a8158fd263018de6d40bd78f312e6bfba754e737b64e6c6b3d
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.7.0":
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.2.2, @codemirror/view@npm:^6.6.0, @codemirror/view@npm:^6.7.0":
   version: 6.9.3
   resolution: "@codemirror/view@npm:6.9.3"
   dependencies:
@@ -1801,6 +2034,7 @@ __metadata:
     "@jupyterlab/application": ^4.0.0-alpha.22
     "@jupyterlab/apputils": ^4.0.0-alpha.22
     "@jupyterlab/builder": ^4.0.0-alpha.22
+    "@jupyterlab/codemirror": ^4.0.0-alpha.22
     "@jupyterlab/coreutils": ^6.0.0-alpha.22
     "@jupyterlab/filebrowser": ^4.0.0-alpha.22
     "@jupyterlab/services": ^7.0.0-alpha.22
@@ -1833,6 +2067,7 @@ __metadata:
     "@lumino/coreutils": ^2.0.0
     "@lumino/virtualdom": ^2.0.0
     "@lumino/widgets": ^2.0.0
+    "@types/react": ^18.0.27
     react: ^18.2.0
     rimraf: ^4.1.2
     typescript: ~5.0.2
@@ -2019,6 +2254,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/codemirror@npm:^4.0.0-alpha.22":
+  version: 4.0.0-alpha.22
+  resolution: "@jupyterlab/codemirror@npm:4.0.0-alpha.22"
+  dependencies:
+    "@codemirror/autocomplete": ^6.4.0
+    "@codemirror/commands": ^6.1.0
+    "@codemirror/lang-cpp": ^6.0.0
+    "@codemirror/lang-css": ^6.0.0
+    "@codemirror/lang-html": ^6.4.0
+    "@codemirror/lang-java": ^6.0.0
+    "@codemirror/lang-javascript": ^6.1.0
+    "@codemirror/lang-json": ^6.0.0
+    "@codemirror/lang-markdown": ^6.0.0
+    "@codemirror/lang-php": ^6.0.0
+    "@codemirror/lang-python": ^6.1.0
+    "@codemirror/lang-rust": ^6.0.0
+    "@codemirror/lang-sql": ^6.3.0
+    "@codemirror/lang-wast": ^6.0.0
+    "@codemirror/lang-xml": ^6.0.0
+    "@codemirror/language": ^6.4.0
+    "@codemirror/legacy-modes": ^6.3.0
+    "@codemirror/search": ^6.2.0
+    "@codemirror/state": ^6.2.0
+    "@codemirror/view": ^6.7.0
+    "@jupyter/ydoc": ^0.3.4
+    "@jupyterlab/codeeditor": ^4.0.0-alpha.22
+    "@jupyterlab/coreutils": ^6.0.0-alpha.22
+    "@jupyterlab/documentsearch": ^4.0.0-alpha.22
+    "@jupyterlab/nbformat": ^4.0.0-alpha.22
+    "@jupyterlab/translation": ^4.0.0-alpha.22
+    "@lezer/common": ^1.0.0
+    "@lezer/generator": ^1.0.0
+    "@lezer/highlight": ^1.0.0
+    "@lumino/coreutils": ^2.0.0
+    "@lumino/disposable": ^2.0.0
+    "@lumino/signaling": ^2.0.0
+    yjs: ^13.5.40
+  checksum: ae4fddf6a9269c51fa461b3683ea050005d6b1b826d9a6b570e49260b694ab66a4fe7547b97bb77a2c984e2ce498f728327a4bd4cdf4cc5cbb1281598e90aa74
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/coreutils@npm:^6.0.0-alpha.22":
   version: 6.0.0-alpha.22
   resolution: "@jupyterlab/coreutils@npm:6.0.0-alpha.22"
@@ -2078,6 +2354,24 @@ __metadata:
     "@lumino/signaling": ^2.0.0
     "@lumino/widgets": ^2.0.0
   checksum: f2323d3ddec436bd47eb54324dd609376078ef785e977319fb6c41cf900d146fcea499f54a3736a2e0d9f4f4187c0b2dd4cc6ebc7abb0e7b580476df3325efe1
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/documentsearch@npm:^4.0.0-alpha.22":
+  version: 4.0.0-alpha.22
+  resolution: "@jupyterlab/documentsearch@npm:4.0.0-alpha.22"
+  dependencies:
+    "@jupyterlab/apputils": ^4.0.0-alpha.22
+    "@jupyterlab/translation": ^4.0.0-alpha.22
+    "@jupyterlab/ui-components": ^4.0.0-alpha.37
+    "@lumino/coreutils": ^2.0.0
+    "@lumino/disposable": ^2.0.0
+    "@lumino/messaging": ^2.0.0
+    "@lumino/polling": ^2.0.0
+    "@lumino/signaling": ^2.0.0
+    "@lumino/widgets": ^2.0.0
+    react: ^18.2.0
+  checksum: fd0b55ab222ba625334f0820b66ca5eded36154353c2b84b01f22f9f7b422f1b3b5ca8a673adbcd13fa1904ab3c869d6c2d5d891837481387f6f10c93317a41f
   languageName: node
   linkType: hard
 
@@ -2329,6 +2623,154 @@ __metadata:
     validate-npm-package-name: ^4.0.0
     yargs-parser: 20.2.4
   checksum: dd2c7ffd555468b7e11302de5f2a4da65fa944769c6962be1742db144ee8cf415adf240cfc3a7eca20b8749d7e0f77e716f92359a19431356fce0e2d103e32a5
+  languageName: node
+  linkType: hard
+
+"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@lezer/common@npm:1.0.2"
+  checksum: bbcc58e07be02652bf0700d2856042ec089d5be0b95893d628b3e18192ade864fac83b61b19653e10b9f1472261a178b12318d934e9004edd5483a577c0db56b
+  languageName: node
+  linkType: hard
+
+"@lezer/cpp@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@lezer/cpp@npm:1.1.0"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 9b25c881fc9b64fd2b019a077a85b0ba7cfda0bbdd92dbb0ff43300c9ba1ec4360128fe912bfe0f06a1c1bb5a564c5ace375c8aad254d07a717768a8f268695d
+  languageName: node
+  linkType: hard
+
+"@lezer/css@npm:^1.0.0, @lezer/css@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@lezer/css@npm:1.1.1"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: a7e4893aacaa7f26d5679c77a640f401b37d14155cb54863aa91b59dfd220b280360a341c0fedafc65d31101de13a5ae33cf3876c352f2da528344dafdc9b3d7
+  languageName: node
+  linkType: hard
+
+"@lezer/generator@npm:^1.0.0":
+  version: 1.2.2
+  resolution: "@lezer/generator@npm:1.2.2"
+  dependencies:
+    "@lezer/common": ^1.0.2
+    "@lezer/lr": ^1.3.0
+  bin:
+    lezer-generator: dist/lezer-generator.cjs
+  checksum: 62f93704d7b0b53bbd842c65552b9089f354edbf5f50f05d65a214a5dba05c0a63c898ca448a93ecc803d5b8b05d5eb593a5e5509c478c8dfa3b49ff28dcafb3
+  languageName: node
+  linkType: hard
+
+"@lezer/highlight@npm:^1.0.0, @lezer/highlight@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@lezer/highlight@npm:1.1.3"
+  dependencies:
+    "@lezer/common": ^1.0.0
+  checksum: 90ec143ce46b32f6779c3b245f1b5a540d66686939816d3daed8318821acc4bc719466dc222336cfd483bf04a8de4fdc6f279e904cf114d4d9f786f9feccbbd8
+  languageName: node
+  linkType: hard
+
+"@lezer/html@npm:^1.3.0":
+  version: 1.3.3
+  resolution: "@lezer/html@npm:1.3.3"
+  dependencies:
+    "@lezer/common": ^1.0.0
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: ad74a5a751daead9d5979a4e1dc55faf94e623672d6b835e4d84d7a1174f326fa6b511a354f6dd5ec4c0b375242614966607ecf07cc92e5c13afe882178fe01d
+  languageName: node
+  linkType: hard
+
+"@lezer/java@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@lezer/java@npm:1.0.3"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 2fffea6627d130413ffad4e61040267974cca3167d98881b9e5b5e2455530de74a82c234d93603e92a4972fad314671453c49c0a76b0f4547c4617d671fd7b99
+  languageName: node
+  linkType: hard
+
+"@lezer/javascript@npm:^1.0.0":
+  version: 1.4.1
+  resolution: "@lezer/javascript@npm:1.4.1"
+  dependencies:
+    "@lezer/highlight": ^1.1.3
+    "@lezer/lr": ^1.3.0
+  checksum: 634270116d5f1c278e2949d397845f41cac388dec7f0db593a3dc23e0fd4a1b73b9bf08f96fcf109fcd3d38c4b374d48676dce3261ff8ff83a85f5d6a37989f7
+  languageName: node
+  linkType: hard
+
+"@lezer/json@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@lezer/json@npm:1.0.0"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: c1ca0cdf681415b58a383a669944bed66da3aa830870d32d1e471d545cff0fe43d9ac8a0d2a318a96daa99cd5a645b1d58ba8fbdd2e8d7ca4d33a62c7582cbab
+  languageName: node
+  linkType: hard
+
+"@lezer/lr@npm:^1.0.0, @lezer/lr@npm:^1.1.0, @lezer/lr@npm:^1.3.0":
+  version: 1.3.3
+  resolution: "@lezer/lr@npm:1.3.3"
+  dependencies:
+    "@lezer/common": ^1.0.0
+  checksum: 1804074c794005a31c54d80ab72127f19ae5be29bb627c52bc001a57b1af97a9e62732ff13e3aeb7bc53b330202b6bd3747272c64d87f257dbba533e75a183a3
+  languageName: node
+  linkType: hard
+
+"@lezer/markdown@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "@lezer/markdown@npm:1.0.2"
+  dependencies:
+    "@lezer/common": ^1.0.0
+    "@lezer/highlight": ^1.0.0
+  checksum: c4bbfcd8a5a9d924a7cf2b5e5e99c78e7705473cc59804070278b5cfcf478af9dd567025d0926cbf03e3ea6abb8f173425220d3107c05a2d7e0ca3fe3d5c92ef
+  languageName: node
+  linkType: hard
+
+"@lezer/php@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@lezer/php@npm:1.0.1"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.1.0
+  checksum: a847c255c030b4d38913ddf1d5bd7324d83be7ef8d1d244542870be03b9bf7dc71283afeb2415c40dfd188cb99f0cc44bad760b5f3b7c35c3b8e5e00253848fc
+  languageName: node
+  linkType: hard
+
+"@lezer/python@npm:^1.0.0":
+  version: 1.1.3
+  resolution: "@lezer/python@npm:1.1.3"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 6c621b8970a27ccc7f74a4cabf38de4f25904497448c6fd4416e0e613355d12565f722cdddb513a05c76e6ab64cef9060acefb19e4d39d7b0a47589c6f81e2bc
+  languageName: node
+  linkType: hard
+
+"@lezer/rust@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@lezer/rust@npm:1.0.0"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 0c42f415674f60ca2ef4274b446577621cdeec8f31168b1c3b90888a4377c513f02a89ee346421c264ec3a77fe2fa3e134996be6463ed506dbbc79b4b4505375
+  languageName: node
+  linkType: hard
+
+"@lezer/xml@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@lezer/xml@npm:1.0.1"
+  dependencies:
+    "@lezer/highlight": ^1.0.0
+    "@lezer/lr": ^1.0.0
+  checksum: 271319aa7802c123845b70ffa63d7065c0f92fc6a1ddb1f8ec9f3aa965bca3df3c9fad4d4de53187ddf230e833cd3ab3a84cb2aded76ab5f6831e9a2fc310923
   languageName: node
   linkType: hard
 
@@ -4947,6 +5389,13 @@ __metadata:
     parse-json: ^5.0.0
     path-type: ^4.0.0
   checksum: ff4cdf89ac1ae52e7520816622c21a9e04380d04b82d653f5139ec581aa4f7f29e096d46770bc76c4a63c225367e88a1dfa233ea791669a35101f5f9b972c7d1
+  languageName: node
+  linkType: hard
+
+"crelt@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "crelt@npm:1.0.5"
+  checksum: 04a618c5878e12a14a9a328a49ff6e37bed76abb88b72e661c56b5f161d8a9aca133650da6bcbc5224ad1f7f43a69325627f209e92a21002986d52a8f844b367
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,10 +1324,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:^6.2.0":
+"@codemirror/state@npm:^6.1.4, @codemirror/state@npm:^6.2.0":
   version: 6.2.0
   resolution: "@codemirror/state@npm:6.2.0"
   checksum: fdc99c773dc09c700dd02bf918f06132aa8d3069c262cc4eb6ca5c810ce24ae2d7e90719ae7630a8158fd263018de6d40bd78f312e6bfba754e737b64e6c6b3d
+  languageName: node
+  linkType: hard
+
+"@codemirror/view@npm:^6.7.0":
+  version: 6.9.3
+  resolution: "@codemirror/view@npm:6.9.3"
+  dependencies:
+    "@codemirror/state": ^6.1.4
+    style-mod: ^4.0.0
+    w3c-keyname: ^2.2.4
+  checksum: 718ecbb021ca75eb89003f73c846a07d36a708dcfec8345f0f0dbcfc0d0df5ea6f114918694b2730a6d49e5e50502bcce79ce7ff94ce55748e068e5a35073755
   languageName: node
   linkType: hard
 
@@ -1813,6 +1824,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter/collaboration@workspace:packages/collaboration"
   dependencies:
+    "@codemirror/state": ^6.2.0
+    "@codemirror/view": ^6.7.0
     "@jupyterlab/apputils": ^4.0.0-alpha.22
     "@jupyterlab/coreutils": ^6.0.0-alpha.22
     "@jupyterlab/services": ^7.0.0-alpha.22
@@ -11348,6 +11361,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-mod@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "style-mod@npm:4.0.2"
+  checksum: 4bac8877e039c61481fc729981378791979c3ebb2f827a54240e95ccca5bca92a6d660566cacb87a8d7cc1ffb26bcd5eafa10c697e131adb5ca9541f3a9cbff6
+  languageName: node
+  linkType: hard
+
 "style-search@npm:^0.1.0":
   version: 0.1.0
   resolution: "style-search@npm:0.1.0"
@@ -12244,6 +12264,13 @@ __metadata:
   version: 8.0.0
   resolution: "vscode-textmate@npm:8.0.0"
   checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
+  languageName: node
+  linkType: hard
+
+"w3c-keyname@npm:^2.2.4":
+  version: 2.2.6
+  resolution: "w3c-keyname@npm:2.2.6"
+  checksum: 59a31d23ca9953c01c99ed6695fee5b6ea36eb2412d76a21fe4302ab33a3f5cd96c006a763940b6115c3d042c16d3564eeee1156832217d028af0518098b3a42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This add an CodeMirror extension to display remote user cursors.

![image](https://user-images.githubusercontent.com/8435071/225703832-6c41e1ce-0aef-4cb9-be56-b08c02137ea4.png)

This uses a view plugin to communicate the user cursors through the awareness. Then the UI elements are displayed in 3 companion extensions:
- A remote cursors layer
- A remote selection layer
- Hover on tooltip to display user info