### PR TITLE
Fix injecting user menu bar in top bar.

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -1,3 +1,6 @@
+.. Copyright (c) Jupyter Development Team.
+.. Distributed under the terms of the Modified BSD License.
+
 Developer documentation
 =======================
 

--- a/jupyter_collaboration/__init__.py
+++ b/jupyter_collaboration/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from typing import Any, Dict, List
 
 from ._version import __version__  # noqa

--- a/jupyter_collaboration/loaders.py
+++ b/jupyter_collaboration/loaders.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from __future__ import annotations
 
 import asyncio

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from __future__ import annotations
 
 import asyncio

--- a/jupyter_collaboration/utils.py
+++ b/jupyter_collaboration/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import pathlib
 from enum import Enum
 from typing import Tuple

--- a/packages/collaboration-extension/src/collaboration.ts
+++ b/packages/collaboration-extension/src/collaboration.ts
@@ -9,7 +9,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { DOMUtils } from '@jupyterlab/apputils';
+import { DOMUtils, IToolbarWidgetRegistry } from '@jupyterlab/apputils';
 import {
   EditorExtensionRegistry,
   IEditorExtensionRegistry
@@ -54,12 +54,15 @@ export const userMenuPlugin: JupyterFrontEndPlugin<IUserMenu> = {
  * Jupyter plugin adding the IUserMenu to the menu bar if collaborative flag enabled.
  */
 export const menuBarPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyter/collaboration-extension:userMenuBar',
+  id: '@jupyter/collaboration-extension:user-menu-bar',
   description: 'Add user menu to the interface.',
   autoStart: true,
-  requires: [IUserMenu],
-  activate: async (app: JupyterFrontEnd, menu: IUserMenu): Promise<void> => {
-    const { shell } = app;
+  requires: [IUserMenu, IToolbarWidgetRegistry],
+  activate: async (
+    app: JupyterFrontEnd,
+    menu: IUserMenu,
+    toolbarRegistry: IToolbarWidgetRegistry
+  ): Promise<void> => {
     const { user } = app.serviceManager;
 
     const menuBar = new MenuBar({
@@ -72,7 +75,8 @@ export const menuBarPlugin: JupyterFrontEndPlugin<void> = {
     menuBar.id = 'jp-UserMenu';
     user.userChanged.connect(() => menuBar.update());
     menuBar.addMenu(menu as Menu);
-    shell.add(menuBar, 'top', { rank: 1000 });
+
+    toolbarRegistry.addFactory('TopBar', 'user-menu', () => menuBar);
   }
 };
 

--- a/packages/collaboration-extension/src/filebrowser.ts
+++ b/packages/collaboration-extension/src/filebrowser.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 import {
   ILabShell,
   IRouter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling>=1.4.0", "hatch-nodejs-version", "jupyterlab>=4.0.0rc0"]

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 # setup.py shim for use with applications that require it.
 __import__("setuptools").setup()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,4 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 pytest_plugins = ["jupyter_server.pytest_plugin"]

--- a/tests/test_ydoc.py
+++ b/tests/test_ydoc.py
@@ -1,2 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 def test_ydoc():
     pass


### PR DESCRIPTION
The user menu bar was having mixed configuration giving the impression it is injected in the top bar through the toolbar registry when it was not.

This fixes it.